### PR TITLE
Default to plotting a maximum of 50 precinct-level ridgeplots

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -1,4 +1,5 @@
 """Plotting functions for visualizing ei outputs"""
+import warnings
 import seaborn as sns
 import pandas as pd
 from matplotlib import pyplot as plt
@@ -13,7 +14,9 @@ __all__ = [
 ]
 
 
-def plot_precincts(voting_prefs_group1, voting_prefs_group2, y_labels=None, ax=None):
+def plot_precincts(
+    voting_prefs_group1, voting_prefs_group2, y_labels=None, show_all_precincts=False, ax=None
+):
     """Ridgeplots of sampled voting preferences for each precinct"""
     n_x_pts = 500
     overlap = 1.3
@@ -21,6 +24,18 @@ def plot_precincts(voting_prefs_group1, voting_prefs_group2, y_labels=None, ax=N
         _, ax = plt.subplots()
     x = np.linspace(0, 1, n_x_pts)
 
+    N = voting_prefs_group1.shape[1]
+    if N > 50 and not show_all_precincts:
+        warnings.warn(
+            f"User attempted to plot {N} precinct-level voting preference "
+            f"ridgeplots. Automatically restricting to first 50 precincts "
+            f"(run with `show_all_precincts=True` to plot all precinct ridgeplots.)"
+        )
+        voting_prefs_group1 = voting_prefs_group1[:, :50]
+        voting_prefs_group2 = voting_prefs_group2[:, :50]
+        if y_labels is not None:
+            y_labels = y_labels[:50]
+        N = 50
     if y_labels is None:
         y_labels = range(N)
 

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -18,11 +18,10 @@ def plot_precincts(
     voting_prefs_group1, voting_prefs_group2, y_labels=None, show_all_precincts=False, ax=None
 ):
     """Ridgeplots of sampled voting preferences for each precinct"""
-    n_x_pts = 500
     overlap = 1.3
     if ax is None:
         _, ax = plt.subplots()
-    x = np.linspace(0, 1, n_x_pts)
+    x = np.linspace(0, 1, 500)  # 500 points between 0 and 1 on the x-axis
 
     N = voting_prefs_group1.shape[1]
     if N > 50 and not show_all_precincts:

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -21,7 +21,6 @@ def plot_precincts(voting_prefs_group1, voting_prefs_group2, y_labels=None, ax=N
         _, ax = plt.subplots()
     x = np.linspace(0, 1, n_x_pts)
 
-    N = voting_prefs_group1.shape[1]
     if y_labels is None:
         y_labels = range(N)
 

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -5,6 +5,7 @@ TODO: Finish wakefield model
 TODO: Truncated normal model
 """
 
+import warnings
 import pymc3 as pm
 import numpy as np
 import matplotlib.pyplot as plt
@@ -248,11 +249,34 @@ class TwoByTwoEI:
         _, (ax1, ax2, ax3) = plt.subplots(nrows=3)
         return (self.plot_kde(ax1), self.plot_boxplot(ax2), self.plot_intervals(ax3))
 
-    def precinct_level_plot(self, ax=None):
-        """Ridgeplots for precincts"""
+    def precinct_level_plot(self, ax=None, force_print_all=False, y_labels=None):
+        """Ridgeplots for precincts
+        
+            Optional arguments:
+            
+            ax               :  matplotlib axes object
+            force_print_all  :  If True, then it will show all ridge plots (even 
+                                if there are more than 50)
+            y_labels         :  Labels for each precinct (if not supplied, by
+                                default we label each precinct with an integer
+                                label, 1 to n)
+        """
+        voting_prefs_group1 = self.sim_trace.get_values("b_1")
+        voting_prefs_group2 = self.sim_trace.get_values("b_2")
+        N = voting_prefs_group1.shape[1]
+        if N > 50 and not force_print_all:
+            message = (f"User attempted to plot {N} precinct-level voting preference ridgeplots. "
+                       f"Automatically restricting to first 50 precincts "
+                       f"(run with `force_print_all=True` to plot all precinct ridgeplots.)")
+            warnings.warn(message)
+            voting_prefs_group1 = voting_prefs_group1[:, :50]
+            voting_prefs_group2 = voting_prefs_group2[:, :50]
+            if y_labels is not None:
+                y_labels = y_labels[:50]
+
         return plot_precincts(
-            self.sim_trace.get_values("b_1"),
-            self.sim_trace.get_values("b_2"),
-            y_labels=None,
+            voting_prefs_group1,
+            voting_prefs_group2,
+            y_labels=y_labels,
             ax=ax,
         )

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -5,7 +5,6 @@ TODO: Finish wakefield model
 TODO: Truncated normal model
 """
 
-import warnings
 import pymc3 as pm
 import numpy as np
 import matplotlib.pyplot as plt
@@ -251,32 +250,18 @@ class TwoByTwoEI:
 
     def precinct_level_plot(self, ax=None, show_all_precincts=False, y_labels=None):
         """Ridgeplots for precincts
-        
             Optional arguments:
-            
             ax                  :  matplotlib axes object
-            show_all_precincts  :  If True, then it will show all ridge plots (even 
-                                   if there are more than 50)
+            show_all_precincts  :  If True, then it will show all ridge plots
+                                   (even if there are more than 50)
             y_labels            :  Labels for each precinct (if not supplied, by
                                    default we label each precinct with an integer
                                    label, 1 to n)
         """
-        voting_prefs_group1 = self.sim_trace.get_values("b_1")
-        voting_prefs_group2 = self.sim_trace.get_values("b_2")
-        N = voting_prefs_group1.shape[1]
-        if N > 50 and not show_all_precincts:
-            message = (f"User attempted to plot {N} precinct-level voting preference "
-                       f"ridgeplots. Automatically restricting to first 50 precincts "
-                       f"(run with `show_all_precincts=True` to plot all precinct ridgeplots.)")
-            warnings.warn(message)
-            voting_prefs_group1 = voting_prefs_group1[:, :50]
-            voting_prefs_group2 = voting_prefs_group2[:, :50]
-            if y_labels is not None:
-                y_labels = y_labels[:50]
-
         return plot_precincts(
-            voting_prefs_group1,
-            voting_prefs_group2,
+            self.sim_trace.get_values("b_1"),
+            self.sim_trace.get_values("b_2"),
             y_labels=y_labels,
+            show_all_precincts=show_all_precincts,
             ax=ax,
         )

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -249,25 +249,25 @@ class TwoByTwoEI:
         _, (ax1, ax2, ax3) = plt.subplots(nrows=3)
         return (self.plot_kde(ax1), self.plot_boxplot(ax2), self.plot_intervals(ax3))
 
-    def precinct_level_plot(self, ax=None, force_print_all=False, y_labels=None):
+    def precinct_level_plot(self, ax=None, show_all_precincts=False, y_labels=None):
         """Ridgeplots for precincts
         
             Optional arguments:
             
-            ax               :  matplotlib axes object
-            force_print_all  :  If True, then it will show all ridge plots (even 
-                                if there are more than 50)
-            y_labels         :  Labels for each precinct (if not supplied, by
-                                default we label each precinct with an integer
-                                label, 1 to n)
+            ax                  :  matplotlib axes object
+            show_all_precincts  :  If True, then it will show all ridge plots (even 
+                                   if there are more than 50)
+            y_labels            :  Labels for each precinct (if not supplied, by
+                                   default we label each precinct with an integer
+                                   label, 1 to n)
         """
         voting_prefs_group1 = self.sim_trace.get_values("b_1")
         voting_prefs_group2 = self.sim_trace.get_values("b_2")
         N = voting_prefs_group1.shape[1]
-        if N > 50 and not force_print_all:
-            message = (f"User attempted to plot {N} precinct-level voting preference ridgeplots. "
-                       f"Automatically restricting to first 50 precincts "
-                       f"(run with `force_print_all=True` to plot all precinct ridgeplots.)")
+        if N > 50 and not show_all_precincts:
+            message = (f"User attempted to plot {N} precinct-level voting preference "
+                       f"ridgeplots. Automatically restricting to first 50 precincts "
+                       f"(run with `show_all_precincts=True` to plot all precinct ridgeplots.)")
             warnings.warn(message)
             voting_prefs_group1 = voting_prefs_group1[:, :50]
             voting_prefs_group2 = voting_prefs_group2[:, :50]


### PR DESCRIPTION
While testing, I ran into an issue where calling `model.precinct_level_plot()` appeared to create a completely black rectangle:

![image](https://user-images.githubusercontent.com/5581093/89080708-7dc95100-d33e-11ea-9ea5-e484c916ef27.png)

Turns out, there were just so many precincts that all of the ridge plots were too densely packed, and the end result was just a black rectangle! To address this, `precinct_level_plot()` will now check how many precincts are being plotted. If there are more than 50, it defaults to showing the first 50 and emitting a warning to the user to let them know that not all precincts are being shown. 

![image](https://user-images.githubusercontent.com/5581093/89080618-35aa2e80-d33e-11ea-9cf5-d85049f66318.png)

If the user would like to see all precincts plotted, they can use the flag `show_all_precincts=True`:

![image](https://user-images.githubusercontent.com/5581093/89080640-43f84a80-d33e-11ea-8c40-2725bc717236.png)

