### PR TITLE
Enhance readability of the plots produced by TwoByTwoEI.plot()

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -82,11 +82,9 @@ def plot_kdes(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name
     if ax is None:
         ax = plt.gca()
     ax.set_xlim((0, 1))
-    sns.distplot(voting_prefs_group1, hist=True, ax=ax)
-    sns.distplot(voting_prefs_group2, hist=True, ax=ax)
-    text_pos_y = ax.get_ylim()[1] * 0.9
-    ax.text(voting_prefs_group1.mean(), text_pos_y, group1_name)
-    ax.text(voting_prefs_group2.mean(), text_pos_y, group2_name)
+    sns.distplot(voting_prefs_group1, hist=True, ax=ax, label=group1_name)
+    sns.distplot(voting_prefs_group2, hist=True, ax=ax, label=group2_name)
+    ax.legend()
     return ax
 
 

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -245,7 +245,9 @@ class TwoByTwoEI:
 
     def plot(self):
         """kde, boxplot, and credible intervals"""
-        _, (ax1, ax2, ax3) = plt.subplots(nrows=3)
+        _, (ax1, ax2, ax3) = plt.subplots(
+            nrows=3, figsize=(6.4, 6.4), gridspec_kw={"height_ratios": [2, 1, 1]}
+        )
         return (self.plot_kde(ax1), self.plot_boxplot(ax2), self.plot_intervals(ax3))
 
     def precinct_level_plot(self, ax=None):


### PR DESCRIPTION
# Changes
* Added legend to KDE plots
* Add more vertical space to subplots and make the ratio of heights for the individual subplots 2:1:1, so none of the axis labels overlap

Below I show an example of a call to `TwoByTwoEI.plot()`, before and after the change. Figures were generated in a notebook in Jupyter Lab.

## `TwoByTwoEI.plot()`, before change

King '99 w/ Pareto modification run on Lowell, measuring support for Nuon among Asians and non-Asians

![image](https://user-images.githubusercontent.com/5581093/89216144-c8d1a700-d57e-11ea-986b-0bb42a897537.png)

(Note how default labels, "given demographic group" and "non-given demographic group", overlap. Also note how the axis labels at the bottom of each plot are partially covered by the other graphs, since there isn't enough vertical space.)

## `TwoByTwoEI.plot()`, after change

![image](https://user-images.githubusercontent.com/5581093/89216291-fa4a7280-d57e-11ea-800f-a988f12890d7.png)
