### PR TITLE
Alter default plotting function for TwoByTwoEI to show boxplot above KDE

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -83,7 +83,7 @@ def plot_boxplot(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
     if ax is None:
         ax = plt.gca()
     samples_df = pd.DataFrame({group1_name: voting_prefs_group1, group2_name: voting_prefs_group2})
-    ax = sns.boxplot(data=samples_df, orient="h", ax=ax)
+    ax = sns.boxplot(data=samples_df, orient="h", whis=[5, 95], ax=ax)
     ax.set_xlim((0, 1))
     return ax
 

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -1,7 +1,6 @@
 """Plotting functions for visualizing ei outputs"""
 import warnings
 import seaborn as sns
-import pandas as pd
 from matplotlib import pyplot as plt
 import numpy as np
 import scipy.stats as st
@@ -86,6 +85,41 @@ def plot_boxplot(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
     ax = sns.boxplot(data=samples_df, orient="h", ax=ax)
     ax.set_xlim((0, 1))
     return ax
+
+
+def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name, ax=None):
+    """ Plot KDE, histogram, and boxplot"""
+    _, (ax_box, ax_hist) = plt.subplots(
+            2, sharex=True, figsize=(12, 6.4), gridspec_kw={"height_ratios": (.15, .85)}
+    )
+    sns.despine(ax=ax_hist)
+    sns.despine(ax=ax_box, left=True)
+    # plot custom boxplot, with two boxplots in the same row
+    colors = sns.color_palette()  # fetch seaborn default color palette
+    plot_props = dict(fliersize=5, linewidth=2, whis=[5, 95])
+    flier1_props = dict(marker="o", markerfacecolor=colors[0], alpha=0.5)
+    flier2_props = dict(marker="d", markerfacecolor=colors[1], alpha=0.5)
+    sns.boxplot(
+        voting_prefs_group1,
+        orient="h",
+        color=colors[0],
+        ax=ax_box,
+        flierprops=flier1_props,
+        **plot_props
+    )
+    sns.boxplot(
+        voting_prefs_group2,
+        orient="h",
+        color=colors[1],
+        ax=ax_box,
+        flierprops=flier2_props,
+        **plot_props
+    )
+    ax_box.tick_params(axis="y", left=False)  # remove y axis ticks
+
+    # plot distribution
+    plot_kdes(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name, ax=ax_hist)
+    return (ax_box, ax_hist)
 
 
 def plot_kdes(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name, ax=None):

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -88,7 +88,9 @@ def plot_boxplot(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
     return ax
 
 
-def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name):
+def plot_summary(
+    voting_prefs_group1, voting_prefs_group2, group1_name, group2_name, candidate_name
+):
     """ Plot KDE, histogram, and boxplot"""
     _, (ax_box, ax_hist) = plt.subplots(
         2, sharex=True, figsize=(12, 6.4), gridspec_kw={"height_ratios": (0.15, 0.85)}
@@ -120,6 +122,7 @@ def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
 
     # plot distribution
     plot_kdes(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name, ax=ax_hist)
+    ax_hist.set_xlabel(f"Support for {candidate_name}")
     return (ax_box, ax_hist)
 
 

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -1,6 +1,7 @@
 """Plotting functions for visualizing ei outputs"""
 import warnings
 import seaborn as sns
+import pandas as pd
 from matplotlib import pyplot as plt
 import numpy as np
 import scipy.stats as st
@@ -87,10 +88,10 @@ def plot_boxplot(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
     return ax
 
 
-def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name, ax=None):
+def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_name):
     """ Plot KDE, histogram, and boxplot"""
     _, (ax_box, ax_hist) = plt.subplots(
-            2, sharex=True, figsize=(12, 6.4), gridspec_kw={"height_ratios": (.15, .85)}
+        2, sharex=True, figsize=(12, 6.4), gridspec_kw={"height_ratios": (0.15, 0.85)}
     )
     sns.despine(ax=ax_hist)
     sns.despine(ax=ax_box, left=True)
@@ -105,7 +106,7 @@ def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
         color=colors[0],
         ax=ax_box,
         flierprops=flier1_props,
-        **plot_props
+        **plot_props,
     )
     sns.boxplot(
         voting_prefs_group2,
@@ -113,7 +114,7 @@ def plot_summary(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
         color=colors[1],
         ax=ax_box,
         flierprops=flier2_props,
-        **plot_props
+        **plot_props,
     )
     ax_box.tick_params(axis="y", left=False)  # remove y axis ticks
 

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -13,6 +13,7 @@ from .plot_utils import (
     plot_boxplot,
     plot_kdes,
     plot_precincts,
+    plot_summary
 )
 
 __all__ = ["TwoByTwoEI"]
@@ -243,12 +244,9 @@ class TwoByTwoEI:
             ax=ax,
         )
 
-    def plot(self):
+    def plot(self, ax=None):
         """kde, boxplot, and credible intervals"""
-        _, (ax1, ax2, ax3) = plt.subplots(
-            nrows=3, figsize=(6.4, 6.4), gridspec_kw={"height_ratios": [2, 1, 1]}
-        )
-        return (self.plot_kde(ax1), self.plot_boxplot(ax2), self.plot_intervals(ax3))
+        return plot_summary(*self._voting_prefs(), *self._group_names_for_display(), ax=ax)   
 
     def precinct_level_plot(self, ax=None, show_all_precincts=False, y_labels=None):
         """Ridgeplots for precincts

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -7,13 +7,12 @@ TODO: Truncated normal model
 
 import pymc3 as pm
 import numpy as np
-import matplotlib.pyplot as plt
 from .plot_utils import (
     plot_conf_or_credible_interval,
     plot_boxplot,
     plot_kdes,
     plot_precincts,
-    plot_summary
+    plot_summary,
 )
 
 __all__ = ["TwoByTwoEI"]
@@ -244,9 +243,9 @@ class TwoByTwoEI:
             ax=ax,
         )
 
-    def plot(self, ax=None):
+    def plot(self):
         """kde, boxplot, and credible intervals"""
-        return plot_summary(*self._voting_prefs(), *self._group_names_for_display(), ax=ax)   
+        return plot_summary(*self._voting_prefs(), *self._group_names_for_display())
 
     def precinct_level_plot(self, ax=None, show_all_precincts=False, y_labels=None):
         """Ridgeplots for precincts

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -245,7 +245,9 @@ class TwoByTwoEI:
 
     def plot(self):
         """kde, boxplot, and credible intervals"""
-        return plot_summary(*self._voting_prefs(), *self._group_names_for_display())
+        return plot_summary(
+            *self._voting_prefs(), *self._group_names_for_display(), self.candidate_name,
+        )
 
     def precinct_level_plot(self, ax=None, show_all_precincts=False, y_labels=None):
         """Ridgeplots for precincts


### PR DESCRIPTION
# Description of changes
`TwoByTwoEI.plot()` is meant to show a figure that succinctly communicates the results of the EI fit. Here, I condense the previously shown three figures to two figures that share an x-axis, in hopes of communicating as much visual information as possible in a more condensed form. 

* Create new method `plot_summary` that creates a boxplot with whiskers at the 5th and 95th percentiles
* Modify the `plot_boxplot` so that whiskers are by default at the 5th and 95th percnetiles

Feedback appreciated! (for example, I was debating whether to put "95% credible intervals" somewhere under the top boxplot, but ultimately I felt like the user would still get the gist even without that label.)

# Before change
![image](https://user-images.githubusercontent.com/5581093/89697343-9ef6e800-d8d0-11ea-9f8a-37a356aa853e.png)

# After change
![image](https://user-images.githubusercontent.com/5581093/89697734-54766b00-d8d2-11ea-9bb9-83438c73815a.png)
