### PR TITLE
Allow user to plot ridgeplots for specific precincts by passing in names of precincts

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -107,7 +107,7 @@ def plot_boxplot(voting_prefs_group1, voting_prefs_group2, group1_name, group2_n
     if ax is None:
         ax = plt.gca()
     samples_df = pd.DataFrame({group1_name: voting_prefs_group1, group2_name: voting_prefs_group2})
-    ax = sns.boxplot(data=samples_df, orient="h", whis=[5, 95], ax=ax)
+    ax = sns.boxplot(data=samples_df, orient="h", whis=[2.5, 97.5], ax=ax)
     ax.set_xlim((0, 1))
     return ax
 

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -3,6 +3,7 @@ import warnings
 import seaborn as sns
 import pandas as pd
 from matplotlib import pyplot as plt
+from matplotlib import ticker as mticker
 import numpy as np
 import scipy.stats as st
 
@@ -14,15 +15,52 @@ __all__ = [
 ]
 
 
+def plot_single_ridgeplot(ax, group1_pref, group2_pref, z_init, trans, overlap=1.3, num_points=500):
+    """ Helper function for plot_precincts that plots a single ridgeplot (e.g.,
+        for a single precinct for a given candidate.)
+        Arguments:
+        ax          :   matplotlib axis object
+        group1_pref :   The estimates for the support for the candidate among
+                        Group 1
+        group2_pref :   The estimates for the support for the candidate among
+                        Group 2
+        z_init      :   The initial value for the z-order (helps determine
+                        how plots get drawn over one another)
+        trans       :   The y-translation for this plot
+        Optional arguments:
+        overlap     :   how much this ridgeplot may overlap with the ridgeplot
+                        above it
+        num_points  :   The number of evenly spaced points in [0, 1] that we
+                        use to plot compute the KDE curve
+    """
+    x = np.linspace(0, 1, num_points)  # 500 points between 0 and 1 on the x-axis
+    group1_kde = st.gaussian_kde(group1_pref)
+    group2_kde = st.gaussian_kde(group2_pref)
+
+    group1_y = group1_kde(x)
+    group1_y = overlap * group1_y / group1_y.max()
+    group2_y = group2_kde(x)
+    group2_y = overlap * group2_y / group2_y.max()
+
+    ax.fill_between(
+        x, group1_y + trans, trans, color="steelblue", zorder=z_init,
+    )
+    ax.plot(x, group1_y + trans, color="black", linewidth=1, zorder=z_init + 1)
+
+    ax.fill_between(
+        x, group2_y + trans, trans, color="orange", zorder=z_init + 2,
+    )
+    ax.plot(x, group2_y + trans, color="black", linewidth=1, zorder=z_init + 3)
+
+
 def plot_precincts(
-    voting_prefs_group1, voting_prefs_group2, y_labels=None, show_all_precincts=False, ax=None
+    voting_prefs_group1,
+    voting_prefs_group2,
+    precinct_labels=None,
+    show_all_precincts=False,
+    ax=None,
 ):
     """Ridgeplots of sampled voting preferences for each precinct"""
-    overlap = 1.3
-    if ax is None:
-        _, ax = plt.subplots()
-    x = np.linspace(0, 1, 500)  # 500 points between 0 and 1 on the x-axis
-
     N = voting_prefs_group1.shape[1]
     if N > 50 and not show_all_precincts:
         warnings.warn(
@@ -32,47 +70,33 @@ def plot_precincts(
         )
         voting_prefs_group1 = voting_prefs_group1[:, :50]
         voting_prefs_group2 = voting_prefs_group2[:, :50]
-        if y_labels is not None:
-            y_labels = y_labels[:50]
+        if precinct_labels is not None:
+            precinct_labels = precinct_labels[:50]
         N = 50
-    if y_labels is None:
-        y_labels = range(N)
+    if precinct_labels is None:
+        precinct_labels = range(1, N + 1)
+    if ax is None:
+        # adapt height of plot to the number of precincts
+        _, ax = plt.subplots(figsize=(6.4, 0.2 * N))
 
-    iterator = zip(y_labels, voting_prefs_group1.T, voting_prefs_group2.T)
+    iterator = zip(voting_prefs_group1.T, voting_prefs_group2.T)
 
-    for idx, (precinct, group1, group2) in enumerate(iterator, 1):
-        pfx = "" if idx == 1 else "_"
-        group1_kde = st.gaussian_kde(group1)
-        group2_kde = st.gaussian_kde(group2)
-        ax.plot([0], [precinct])
-        trans = ax.convert_yunits(precinct)
+    for idx, (group1, group2) in enumerate(iterator, 0):
+        ax.plot([0], [idx])
+        trans = ax.convert_yunits(idx)
+        plot_single_ridgeplot(ax, group1, group2, 4 * N - 4 * idx, trans)
 
-        group1_y = group1_kde(x)
-        group1_y = overlap * group1_y / group1_y.max()
-        group2_y = group2_kde(x)
-        group2_y = overlap * group2_y / group2_y.max()
+    def replace_ticks_with_precinct_names(value, pos):
+        idx = int(value)
+        if idx < len(precinct_labels):
+            return precinct_labels[idx]
+        return value
 
-        ax.fill_between(
-            x,
-            group1_y + trans,
-            trans,
-            color="steelblue",
-            zorder=4 * N - 4 * idx,
-            label=pfx + "Group 1",
-        )
-        ax.plot(x, group1_y + trans, color="black", linewidth=1, zorder=4 * N - 4 * idx + 1)
-
-        ax.fill_between(
-            x,
-            group2_y + trans,
-            trans,
-            color="orange",
-            zorder=4 * N - 4 * idx + 2,
-            label=pfx + "Group 2",
-        )
-        ax.plot(x, group2_y + trans, color="black", linewidth=1, zorder=4 * N - 4 * idx + 3)
+    ax.set_yticks(np.arange(len(precinct_labels)))
+    ax.yaxis.set_major_formatter(mticker.FuncFormatter(replace_ticks_with_precinct_names))
     ax.set_title("Precinct level estimates of voting preferences")
     ax.set_xlabel("Percent vote for candidate")
+    ax.set_ylabel("Precinct")
     return ax
 
 

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -141,7 +141,7 @@ def plot_summary(
     sns.despine(ax=ax_box, left=True)
     # plot custom boxplot, with two boxplots in the same row
     colors = sns.color_palette()  # fetch seaborn default color palette
-    plot_props = dict(fliersize=5, linewidth=2, whis=[5, 95])
+    plot_props = dict(fliersize=5, linewidth=2, whis=[2.5, 97.5])
     flier1_props = dict(marker="o", markerfacecolor=colors[0], alpha=0.5)
     flier2_props = dict(marker="d", markerfacecolor=colors[1], alpha=0.5)
     sns.boxplot(

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -60,7 +60,22 @@ def plot_precincts(
     show_all_precincts=False,
     ax=None,
 ):
-    """Ridgeplots of sampled voting preferences for each precinct"""
+    """ Ridgeplots of sampled voting preferences for each precinct
+        Arguments:
+        voting_prefs_group1 :   A numpy array with shape (# of samples x
+                                # of precincts) representing the estimates
+                                of support for given candidate among group 1
+                                in each precinct in each sample
+        voting_prefs_group2 :   Same as voting_prefs_group2, except showing
+                                support among group 2
+        Optional arguments:
+        precinct_labels     :   The names for each precinct
+        show_all_precincts  :   By default, we only show the first 50 precincts.
+                                If show_all_precincts is True, we plot the
+                                ridgeplots for all precincts (i.e., one ridgeplot
+                                for every column in the voting_prefs matrices)
+        ax                  :   Matplotlib axis object
+    """
     N = voting_prefs_group1.shape[1]
     if N > 50 and not show_all_precincts:
         warnings.warn(
@@ -86,7 +101,7 @@ def plot_precincts(
         trans = ax.convert_yunits(idx)
         plot_single_ridgeplot(ax, group1, group2, 4 * N - 4 * idx, trans)
 
-    def replace_ticks_with_precinct_names(value, pos):
+    def replace_ticks_with_precinct_labels(value, pos):
         # pylint: disable=unused-argument
         # matplotlib axis tick formatter function
         idx = int(value)
@@ -94,8 +109,9 @@ def plot_precincts(
             return precinct_labels[idx]
         return value
 
+    # replace y-axis ticks with precinct labels
     ax.set_yticks(np.arange(len(precinct_labels)))
-    ax.yaxis.set_major_formatter(mticker.FuncFormatter(replace_ticks_with_precinct_names))
+    ax.yaxis.set_major_formatter(mticker.FuncFormatter(replace_ticks_with_precinct_labels))
     ax.set_title("Precinct level estimates of voting preferences")
     ax.set_xlabel("Percent vote for candidate")
     ax.set_ylabel("Precinct")

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -87,6 +87,8 @@ def plot_precincts(
         plot_single_ridgeplot(ax, group1, group2, 4 * N - 4 * idx, trans)
 
     def replace_ticks_with_precinct_names(value, pos):
+        # pylint: disable=unused-argument
+        # matplotlib axis tick formatter function
         idx = int(value)
         if idx < len(precinct_labels):
             return precinct_labels[idx]

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -199,8 +199,8 @@ class TwoByTwoEI:
         )  # sampled voted prefs across precincts
 
         # compute point estimates
-        self.posterior_mean_voting[0] = self.sampled_voting_prefs[0].mean()
-        self.posterior_mean_voting[1] = self.sampled_voting_prefs[1].mean()
+        self.posterior_mean_voting_prefs[0] = self.sampled_voting_prefs[0].mean()
+        self.posterior_mean_voting_prefs[1] = self.sampled_voting_prefs[1].mean()
 
         # compute credible intervals
         percentiles = [2.5, 97.5]
@@ -219,10 +219,10 @@ class TwoByTwoEI:
         the proportion of the total pop (total pop=summed across all districts):
         The posterior mean for the district-level voting preference of
         {self.demographic_group_name} for {self.candidate_name} is
-        {self.posterior_mean_voting_prefs_district[0]:.3f}
+        {self.posterior_mean_voting_prefs[0]:.3f}
         The posterior mean for the district-level voting preference of
         non-{self.demographic_group_name} for {self.candidate_name} is
-        {self.posterior_mean_voting_prefs_district[1]:.3f}
+        {self.posterior_mean_voting_prefs[1]:.3f}
         95% Bayesian credible interval for district-level voting preference of
         {self.demographic_group_name} for {self.candidate_name} is
         {self.credible_interval_95_mean_voting_prefs[0]}

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -116,12 +116,9 @@ class TwoByTwoEI:
         self.demographic_group_name = None
         self.candidate_name = None
         self.sim_trace = None
-        self.sampled_voting_prefs_district_gp1 = None
-        self.sampled_voting_prefs_district_gp2 = None
-        self.posterior_mean_voting_prefs_district_gp1 = None
-        self.posterior_mean_voting_prefs_district_gp2 = None
-        self.credible_interval_95_mean_voting_prefs_district_gp1 = None
-        self.credible_interval_95_mean_voting_prefs_district_gp2 = None
+        self.sampled_voting_prefs = [None, None]
+        self.posterior_mean_voting_prefs = [None, None]
+        self.credible_interval_95_mean_voting_prefs = [None, None]
 
     def fit(
         self,
@@ -194,28 +191,24 @@ class TwoByTwoEI:
         samples_of_votes_summed_across_district_gp2 = samples_converted_to_pops_gp2.sum(axis=1)
 
         # obtain samples of the districtwide proportion of each demog. group voting for candidate
-        self.sampled_voting_prefs_district_gp1 = (
+        self.sampled_voting_prefs[0] = (
             samples_of_votes_summed_across_district_gp1 / self.precinct_pops.sum()
         )  # sampled voted prefs across precincts
-        self.sampled_voting_prefs_district_gp2 = (
+        self.sampled_voting_prefs[1] = (
             samples_of_votes_summed_across_district_gp2 / self.precinct_pops.sum()
         )  # sampled voted prefs across precincts
 
         # compute point estimates
-        self.posterior_mean_voting_prefs_district_gp1 = (
-            self.sampled_voting_prefs_district_gp1.mean()
-        )
-        self.posterior_mean_voting_prefs_district_gp2 = (
-            self.sampled_voting_prefs_district_gp2.mean()
-        )
+        self.posterior_mean_voting[0] = self.sampled_voting_prefs[0].mean()
+        self.posterior_mean_voting[1] = self.sampled_voting_prefs[1].mean()
 
         # compute credible intervals
         percentiles = [2.5, 97.5]
-        self.credible_interval_95_mean_voting_prefs_district_gp1 = np.percentile(
-            self.sampled_voting_prefs_district_gp1, percentiles
+        self.credible_interval_95_mean_voting_prefs[0] = np.percentile(
+            self.sampled_voting_prefs[0], percentiles
         )
-        self.credible_interval_95_mean_voting_prefs_district_gp2 = np.percentile(
-            self.sampled_voting_prefs_district_gp2, percentiles
+        self.credible_interval_95_mean_voting_prefs[1] = np.percentile(
+            self.sampled_voting_prefs[1], percentiles
         )
 
     def summary(self):
@@ -226,16 +219,16 @@ class TwoByTwoEI:
         the proportion of the total pop (total pop=summed across all districts):
         The posterior mean for the district-level voting preference of
         {self.demographic_group_name} for {self.candidate_name} is
-        {self.posterior_mean_voting_prefs_district_gp1:.3f}
+        {self.posterior_mean_voting_prefs_district[0]:.3f}
         The posterior mean for the district-level voting preference of
         non-{self.demographic_group_name} for {self.candidate_name} is
-        {self.posterior_mean_voting_prefs_district_gp2:.3f}
+        {self.posterior_mean_voting_prefs_district[1]:.3f}
         95% Bayesian credible interval for district-level voting preference of
         {self.demographic_group_name} for {self.candidate_name} is
-        {self.credible_interval_95_mean_voting_prefs_district_gp1}
+        {self.credible_interval_95_mean_voting_prefs[0]}
         95% Bayesian credible interval for district-level voting preference of
         non-{self.demographic_group_name} for {self.candidate_name} is
-        {self.credible_interval_95_mean_voting_prefs_district_gp2}
+        {self.credible_interval_95_mean_voting_prefs[1]}
         """
 
     def precinct_level_estimates(self):
@@ -244,8 +237,8 @@ class TwoByTwoEI:
     def _voting_prefs(self):
         """Bundles together the samples, for ease of passing to plots"""
         return (
-            self.sampled_voting_prefs_district_gp1,
-            self.sampled_voting_prefs_district_gp2,
+            self.sampled_voting_prefs[0],
+            self.sampled_voting_prefs[1],
         )
 
     def _group_names_for_display(self):
@@ -264,8 +257,8 @@ class TwoByTwoEI:
         """ Plot of credible intervals for each group"""
         title = "95% credible intervals"
         return plot_conf_or_credible_interval(
-            self.credible_interval_95_mean_voting_prefs_district_gp1,
-            self.credible_interval_95_mean_voting_prefs_district_gp2,
+            self.credible_interval_95_mean_voting_prefs[0],
+            self.credible_interval_95_mean_voting_prefs[1],
             *self._group_names_for_display(),
             self.candidate_name,
             title,


### PR DESCRIPTION

# Changes made
* By default, we show all precincts
* Adapt height of plot to number of precincts being shown
* Decompose `plot_precincts` (which was getting kind of big) into `plot_precincts` and `plot_single_ridgeplot`
* Add informative docstrings to `plot_precincts` and `plot_single_ridgeplot`
* Reduce the number of instance variables in `TwoByTwoEI` (because linter was complaining) by collapsing `self.sampled_voting_prefs_district_gp1 = None; self.sampled_voting_prefs_district_gp2 = None` into `self.sampled_voting_prefs = [None, None]` (same for `self.posterior_mean_voting_prefs_district_gp1/gp2` and `self.credible_interval_95_mean_voting_prefs_district_gp1/gp2`
* A "rider amendment" added along with this change: the box-and-whisker plots now show 95% credible intervals by placing the percentile range from 2.5 to 97.5 (rather than 5 to 95, which it was previously)

# Usage
```
precinct_names = ["P1", "P2", "P3"]
ei.fit(X, T, N, demographic_group_name=demographic_name, candidate_name=candidate_name, precinct_names=precinct_names)
...
ei.precinct_level_plot(precinct_names=["P1, "P2"])
# ridgeplots only shown for P1 and P2
```

# Before changes
![image](https://user-images.githubusercontent.com/5581093/90062547-ae917a80-dc9c-11ea-9b0f-a2d42a561d95.png)
Note: no y-axis label, each curve is not individually labeled on the y-axis

# After changes

## Default behavior (no specification of precinct names)
![image](https://user-images.githubusercontent.com/5581093/90062315-522e5b00-dc9c-11ea-8e4c-d093200b3ce9.png)

## Specifying precincts to be plotted (n=10, n=25, n=60)
![image](https://user-images.githubusercontent.com/5581093/90062341-5d818680-dc9c-11ea-8007-f813862bf538.png)
![image](https://user-images.githubusercontent.com/5581093/90062370-6d996600-dc9c-11ea-8057-13c1f92fcff9.png)
![image](https://user-images.githubusercontent.com/5581093/90062384-75590a80-dc9c-11ea-9239-e20886631974.png)
**Note that we by default will only plot the first 50 precincts, even if they are specified by name by the user. The user has to specify `show_all_precincts=True` for us to show all of them.**