### PR TITLE
Refactor and add tests for data.py

### DIFF
--- a/pyei/data.py
+++ b/pyei/data.py
@@ -1,48 +1,32 @@
 """Helpers for managing data files."""
-# import io
-# import os
-# import pkgutil
+from dataclasses import dataclass
 
 import pandas as pd
 
-__all__ = ["get_data"]
+__all__ = ["Datasets"]
 
 
-def get_data(filename):
-    """Returns a dataframe for example datasets.
+@dataclass
+class _DataSet:
+    """Class to hold datasets and related information.
 
-    Will either load remotely, or locally. Currently supports:
-
-    - santaClara.csv
-    - waterbury.csv
-
-    TODO: Add details about these datasets.
-
-    Parameters
-    ----------
-    filename: str
-        File to load. See above for valid files.
-
-    Returns
-    -------
-    BytesIO of the data
+    TODO: Add description, provenance, and other metadata here.
     """
-    if filename == "santaClara.csv":
-        return pd.read_csv(
-            "https://raw.githubusercontent.com/gerrymandr/ei-app/master/santaClara.csv"
-        )
-    elif filename == "waterbury.csv":
-        return pd.read_csv(
-            "https://raw.githubusercontent.com/gerrymandr/ei-app/master/waterbury.csv"
-        )
-    else:
-        raise ValueError(
-            """get_data() currently only supports filenames "santaClara.csv" or "waterbury.csv".
-        Use, e.g., pandas.read_csv()" if you'd like to load your own data file"""
-        )
 
-    # This does not work yet (9/2/20), but will collect
-    # files checked into pyei/examples/data/<filename>
-    # else:
-    #    data_pkg = "pyei.examples"
-    #    return pd.read_csv(io.BytesIO(pkgutil.get_data(data_pkg, os.path.join("data", filename))))
+    url: str
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Materialize as a pandas dataframe."""
+        return pd.read_csv(self.url)
+
+
+class Datasets:
+    """Available datasets related to ecological inference.
+
+    These support examples in the library. Please open an issue or pull request if you would
+    like to see other specific examples, or have questions about these."""
+
+    Santa_Clara = _DataSet(
+        "https://raw.githubusercontent.com/gerrymandr/ei-app/master/santaClara.csv"
+    )
+    Waterbury = _DataSet("https://raw.githubusercontent.com/gerrymandr/ei-app/master/waterbury.csv")

--- a/pyei/data.py
+++ b/pyei/data.py
@@ -20,7 +20,7 @@ class _DataSet:
         return pd.read_csv(self.url)
 
 
-class Datasets:
+class Datasets:  # pylint: disable=too-few-public-methods
     """Available datasets related to ecological inference.
 
     These support examples in the library. Please open an issue or pull request if you would

--- a/pyei/examples/model_eval_and_comparison_demo.ipynb
+++ b/pyei/examples/model_eval_and_comparison_demo.ipynb
@@ -20,7 +20,7 @@
     "from matplotlib import pyplot as plt\n",
     "from pyei.two_by_two import TwoByTwoEI\n",
     "from pyei.goodmans_er import GoodmansER, GoodmansERBayes\n",
-    "from pyei.data import get_data"
+    "from pyei.data import Datasets"
    ]
   },
   {
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "# Load example data\n",
-    "data = get_data(\"santaClara.csv\")\n",
+    "data = Datasets.Santa_Clara.to_dataset()\n",
     "X = np.array(data[\"pct_e_asian_vote\"])\n",
     "T = np.array(data[\"pct_for_hardy2\"])\n",
     "N = np.array(data[\"total2\"])\n",

--- a/pyei/examples/santa_clara_demo.ipynb
+++ b/pyei/examples/santa_clara_demo.ipynb
@@ -10,7 +10,7 @@
     "import pymc3 as pm\n",
     "from pyei.two_by_two import TwoByTwoEI\n",
     "from pyei.goodmans_er import GoodmansER\n",
-    "from pyei.data import get_data\n",
+    "from pyei.data import Datasets\n",
     "from pyei.plot_utils import tomography_plot"
    ]
   },
@@ -243,7 +243,7 @@
     }
    ],
    "source": [
-    "data = get_data(\"santaClara.csv\")\n",
+    "data = Datasets.Santa_Clara.to_dataframe()\n",
     "X = np.array(data[\"pct_e_asian_vote\"])\n",
     "T = np.array(data[\"pct_for_hardy2\"])\n",
     "N = np.array(data[\"total2\"])\n",

--- a/pyei/examples/santa_clara_demo_r_by_c.ipynb
+++ b/pyei/examples/santa_clara_demo_r_by_c.ipynb
@@ -20,7 +20,7 @@
     "import pandas as pd\n",
     "import pymc3 as pm\n",
     "from pyei.r_by_c import RowByColumnEI\n",
-    "from pyei.data import get_data\n",
+    "from pyei.data import Datasets\n",
     "from pyei.plot_utils import plot_precinct_scatterplot"
    ]
   },
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = get_data(\"santaClara.csv\")\n",
+    "data = Datasets.Santa_Clara.to_dataframe()\n",
     "\n",
     "precinct_pops = np.array(data['total2'])\n",
     "votes_fractions = np.array(data[['pct_for_hardy2', 'pct_for_kolstad2', 'pct_for_nadeem2']]).T\n",

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,3 +1,4 @@
+"""Tests for data.py"""
 import pytest
 
 from pyei import data

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pyei import data
+
+
+@pytest.fixture
+def expected_data_sets():
+    """Hardcode the names of existing datasets.
+
+    We could also use `dir` or `vars`, but this is quicker for now...
+    """
+    return ("Santa_Clara", "Waterbury")
+
+
+def test_data_sets_exist(expected_data_sets):  # pylint: disable=redefined-outer-name
+    for data_set in expected_data_sets:
+        assert hasattr(data.Datasets, data_set)


### PR DESCRIPTION
This might mess up people's notebooks, but I think it is ultimately more friendly. Data access is now through `from pyei.data import Datasets`. Then `Datasets` has tab completion, and each of the datasets has a `to_dataframe()` method, so at the end of the day, you get

```python
from pyei.data import Datasets

waterbury = Datasets.Waterbury.to_dataframe()
```

There are not yet any other methods on the datasets, but you could imagine having a `description`, or license, or something else in the future.

This also (lightly) tests `data.py`. I decided not to test actually loading the datasets, since that requires downloading a file from github, and I guess unit tests shouldn't (generally) require the internet to work.
