### PR TITLE
add legend to precinct_level_plot()

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -9,6 +9,7 @@ from matplotlib import pyplot as plt
 from matplotlib import ticker as mticker
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Rectangle
+import matplotlib.patches as mpatches
 import numpy as np
 import scipy.stats as st
 
@@ -27,7 +28,7 @@ __all__ = [
 ]
 
 
-def plot_single_ridgeplot(ax, group1_pref, group2_pref, z_init, trans, overlap=1.3, num_points=500):
+def plot_single_ridgeplot(ax, group1_pref, group2_pref, colors, z_init, trans, overlap=1.3, num_points=500):
     """Helper function for plot_precincts that plots a single ridgeplot (e.g.,
     for a single precinct for a given candidate.)
 
@@ -40,6 +41,8 @@ def plot_single_ridgeplot(ax, group1_pref, group2_pref, z_init, trans, overlap=1
     group2_pref : array
         The estimates for the support for the candidate among
         Group 2 (array of floats, expected to be between 0 and 1)
+    colors : array
+        The (ordered) names of colors to use to fill ridgeplots
     z_init : float
         The initial value for the z-order (helps determine
         how plots get drawn over one another)
@@ -65,7 +68,7 @@ def plot_single_ridgeplot(ax, group1_pref, group2_pref, z_init, trans, overlap=1
         x,
         group1_y + trans,
         trans,
-        color="steelblue",
+        color=colors[0],
         zorder=z_init,
     )
     ax.plot(x, group1_y + trans, color="black", linewidth=1, zorder=z_init + 1)
@@ -74,15 +77,15 @@ def plot_single_ridgeplot(ax, group1_pref, group2_pref, z_init, trans, overlap=1
         x,
         group2_y + trans,
         trans,
-        color="orange",
+        color=colors[1],
         zorder=z_init + 2,
     )
     ax.plot(x, group2_y + trans, color="black", linewidth=1, zorder=z_init + 3)
 
-
 def plot_precincts(
     voting_prefs_group1,
     voting_prefs_group2,
+    group_names,
     precinct_labels=None,
     show_all_precincts=False,
     ax=None,
@@ -96,6 +99,8 @@ def plot_precincts(
         of support for given candidate among group 1 in each precinct
     voting_prefs_group2 : numpy array
         Same as voting_prefs_group2, except showing support among group 2
+    group_names: list of str
+        The demographic group names, for display in the legend
     precinct_labels : list of str (optional)
         The names for each precinct
     show_all_precincts : bool, optional
@@ -124,16 +129,22 @@ def plot_precincts(
         N = 50
     if precinct_labels is None:
         precinct_labels = range(1, N + 1)
+
+    legend_space = 5
     if ax is None:
         # adapt height of plot to the number of precincts
-        _, ax = plt.subplots(figsize=(6.4, 0.2 * N))
+        _, ax = plt.subplots(figsize=(6.4, 0.2 * (N+legend_space)))
 
     iterator = zip(voting_prefs_group1.T, voting_prefs_group2.T)
 
+    colors = ["steelblue", "orange"]
     for idx, (group1, group2) in enumerate(iterator, 0):
         ax.plot([0], [idx])
         trans = ax.convert_yunits(idx)
-        plot_single_ridgeplot(ax, group1, group2, 4 * N - 4 * idx, trans)
+        plot_single_ridgeplot(ax, group1, group2, colors, 4 * N - 4 * idx, trans)
+    for i in range(legend_space):
+        # add `legend_space` number of lines to the top of the plot for legend
+        ax.plot([0], [idx+i+1])
 
     def replace_ticks_with_precinct_labels(value, pos):
         # pylint: disable=unused-argument
@@ -149,6 +160,11 @@ def plot_precincts(
     ax.set_title("Precinct level estimates of voting preferences")
     ax.set_xlabel("Percent vote for candidate")
     ax.set_ylabel("Precinct")
+
+    proxy_handles = [mpatches.Patch(color=colors[i],
+                                    ec="black",
+                                    label=group_names[i]) for i in range(2)]
+    ax.legend(handles=proxy_handles, loc="upper center")
     return ax
 
 

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -668,6 +668,7 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
         """
         voting_prefs_group1 = self.sim_trace.get_values("b_1")
         voting_prefs_group2 = self.sim_trace.get_values("b_2")
+        group_names = self._group_names_for_display()
         if precinct_names is not None:
             precinct_idxs = [self.precinct_names.index(name) for name in precinct_names]
             voting_prefs_group1 = voting_prefs_group1[:, precinct_idxs]
@@ -675,6 +676,7 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
         return plot_precincts(
             voting_prefs_group1,
             voting_prefs_group2,
+            group_names=group_names,
             precinct_labels=precinct_names,
             show_all_precincts=show_all_precincts,
             ax=ax,


### PR DESCRIPTION
Added a legend to the `ei.precinct_level_plot()` method, which calls `plot_utils.plot_precincts()`. 

We first have to pass the list of demographic group names into `plot_precincts()`. Since there are really `2 x num_precincts` matplotlib `Artists` in the figure, I opted to create proxy handles for the legend. In order to ensure the legend and the KDE's draw the same colors, I put a `colors` list into `plot_precincts()` function body to which both the `plot_single_ridgeplots()` helper and the legend can point. Lastly, there needs to be space for the legend itself! Some experimentation showed me that creating `legend_space = 5` extra lines at the top were enough to comfortably fit the legend box, and this seems to look fine when tested on 10, 20, and 42 precincts.

Miscellaneous thoughts:
- This plotting function currently only supports `2x2` EI, but I don't think it would be crazy hard to generalize it to `RxC`. I see that for the most part, the plotting/summary functions are separated between `2x2` and `RxC`. I imagine that there is certainly more important functionality to implement first, but do we ever want to think about generalizing the functions in `plot_utils` to `RxC`? 
- I noticed that as `num_precincts` increases, so does a the vertical buffer on the top and bottom of the `plot_precincts()` figure. This isn't a huge problem with `num_precincts < 50`, but I wonder how it would look with many more precincts. Since I doubt many people will want to visually inspect hundreds of precincts with this function, this might not be an issue, but wanted to flag!