### PR TITLE
Add test coverage

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -354,7 +354,7 @@ def plot_summary(
 
 def plot_precinct_scatterplot(ei_runs, run_names, candidate, demographic_group="all", ax=None):
     """
-    Given two EI runs, plot precinct-by-precinct comparison of preferences
+    Given two RxC EI runs, plot precinct-by-precinct comparison of preferences
     for a given candidate from a given demographic group.
 
     Parameters

--- a/pyei/r_by_c.py
+++ b/pyei/r_by_c.py
@@ -404,7 +404,7 @@ class RowByColumnEI:
         point_estimates = point_estimates_all[:, group_index, candidate_index]
         intervals = intervals_all[:, group_index, candidate_index, :]
 
-        plot_intervals_all_precincts(
+        return plot_intervals_all_precincts(
             point_estimates,
             intervals,
             candidate_name,

--- a/test/test_r_by_c_plotting.py
+++ b/test/test_r_by_c_plotting.py
@@ -27,7 +27,7 @@ def example_r_by_c_data():
     }
 
 
-def example_r_by_c_ei(example_r_by_c_data):
+def example_r_by_c_ei(example_r_by_c_data):  # pylint: disable=redefined-outer-name
     """Run this to generate an EI instance"""
 
     ei_ex = RowByColumnEI(model_name="multinomial-dirichlet")
@@ -42,14 +42,14 @@ def example_r_by_c_ei(example_r_by_c_data):
 
 
 @pytest.fixture(scope="session")
-def two_r_by_c_ei_runs(example_r_by_c_data):
+def two_r_by_c_ei_runs(example_r_by_c_data):  # pylint: disable=redefined-outer-name
     """use the EI Factory to fix two EI instances for our tests"""
     example_ei_r_by_c_1 = example_r_by_c_ei(example_r_by_c_data)
     example_ei_r_by_c_2 = example_r_by_c_ei(example_r_by_c_data)
     return [example_ei_r_by_c_1, example_ei_r_by_c_2]
 
 
-def test_ei_r_by_c_precinct_scatterplot(two_r_by_c_ei_runs):
+def test_ei_r_by_c_precinct_scatterplot(two_r_by_c_ei_runs):  # pylint: disable=redefined-outer-name
     all_demographics_ax = plot_precinct_scatterplot(
         two_r_by_c_ei_runs, ["Run 1", "Run 2"], "Kolstad"
     )
@@ -60,7 +60,7 @@ def test_ei_r_by_c_precinct_scatterplot(two_r_by_c_ei_runs):
 
 def test_ei_r_by_c_boxplots(two_r_by_c_ei_runs):  # pylint: disable=redefined-outer-name
     # TODO: maybe uncouple this to test the plot utils piece alone
-    example_r_by_c_ei = two_r_by_c_ei_runs[0]
+    example_r_by_c_ei = two_r_by_c_ei_runs[0]  # pylint: disable=redefined-outer-name
     assert example_r_by_c_ei.plot_boxplots() is not None
     assert example_r_by_c_ei.plot_boxplots(plot_by="group") is not None
     with pytest.raises(ValueError):
@@ -69,7 +69,7 @@ def test_ei_r_by_c_boxplots(two_r_by_c_ei_runs):  # pylint: disable=redefined-ou
 
 def test_ei_r_by_c_kdes(two_r_by_c_ei_runs):  # pylint: disable=redefined-outer-name
     # TODO: maybe uncouple this to test the plot utils piece alone
-    example_r_by_c_ei = two_r_by_c_ei_runs[0]
+    example_r_by_c_ei = two_r_by_c_ei_runs[0]  # pylint: disable=redefined-outer-name
     assert example_r_by_c_ei.plot_kdes(plot_by="candidate") is not None
     assert example_r_by_c_ei.plot_kdes(plot_by="group") is not None
     with pytest.raises(ValueError):

--- a/test/test_r_by_c_plotting.py
+++ b/test/test_r_by_c_plotting.py
@@ -27,34 +27,25 @@ def example_r_by_c_data():
     }
 
 
-@pytest.fixture(scope="session")
-def r_by_c_ei_factory(example_r_by_c_data):
-    """Factory fixture for our two RxC EI fixture below"""
+def example_r_by_c_ei(example_r_by_c_data):
+    """Run this to generate an EI instance"""
 
-    class EIFactory:
-        """ EI Factory from which we can `get` several EI instances"""
-
-        def get(self):
-            """Run `.get()` to generate an EI instance"""
-
-            ei_ex = RowByColumnEI(model_name="multinomial-dirichlet")
-            ei_ex.fit(
-                example_r_by_c_data["group_fractions"],
-                example_r_by_c_data["votes_fractions"],
-                example_r_by_c_data["precinct_pops"],
-                example_r_by_c_data["demographic_group_names"],
-                example_r_by_c_data["candidate_names"],
-            )
-            return ei_ex
-
-    return EIFactory()
+    ei_ex = RowByColumnEI(model_name="multinomial-dirichlet")
+    ei_ex.fit(
+        example_r_by_c_data["group_fractions"],
+        example_r_by_c_data["votes_fractions"],
+        example_r_by_c_data["precinct_pops"],
+        example_r_by_c_data["demographic_group_names"],
+        example_r_by_c_data["candidate_names"],
+    )
+    return ei_ex
 
 
 @pytest.fixture(scope="session")
-def two_r_by_c_ei_runs(r_by_c_ei_factory):
+def two_r_by_c_ei_runs(example_r_by_c_data):
     """use the EI Factory to fix two EI instances for our tests"""
-    example_ei_r_by_c_1 = r_by_c_ei_factory.get()
-    example_ei_r_by_c_2 = r_by_c_ei_factory.get()
+    example_ei_r_by_c_1 = example_r_by_c_ei(example_r_by_c_data)
+    example_ei_r_by_c_2 = example_r_by_c_ei(example_r_by_c_data)
     return [example_ei_r_by_c_1, example_ei_r_by_c_2]
 
 
@@ -82,12 +73,14 @@ def test_ei_r_by_c_kdes(two_r_by_c_ei_runs):  # pylint: disable=redefined-outer-
     assert example_r_by_c_ei.plot_kdes(plot_by="candidate") is not None
     assert example_r_by_c_ei.plot_kdes(plot_by="group") is not None
     with pytest.raises(ValueError):
-        example_r_by_c_ei.plor_kdes(plot_by="grupo")
+        example_r_by_c_ei.plot_kdes(plot_by="grupo")
 
 
 def test_ei_r_by_c_intervals_by_precinct(
     two_r_by_c_ei_runs,
 ):  # pylint: disable=redefined-outer-name
     example_r_by_c_ei = two_r_by_c_ei_runs[0]
-    # I think this fails if you assert that it's not none!
-    example_r_by_c_ei.plot_intervals_by_precinct("e_asian", "Kolstad")
+    assert example_r_by_c_ei.plot_intervals_by_precinct("e_asian", "Kolstad") is not None
+    with pytest.raises(ValueError):
+        example_r_by_c_ei.plot_intervals_by_precinct("e_asian", "Kolstaad")
+        example_r_by_c_ei.plot_intervals_by_precinct("ibnd", "Hardy")


### PR DESCRIPTION
Extended/added tests in the `r_by_c_plotting.py` file. Updates include:
- Made `plot_intervals_by_precinct()` match the behavior of other plotting functions by returning a `Matplotlib Axis`.
- Added a test function for `plot_precinct_scatterplot()`. Since this function requires two (usually distinct) EI runs, this required slightly re-thinking how we use fixtures to supply `EI` instances.  The new `two_r_by_c_runs` fixture returns a list of two EI instances, which are then called by the various testing functions. Only `plot_precinct_scatterplot()` function needs both EI instances, the rest just call the first instance.
- Added testing for typos in plotting function arguments, making sure that a `ValueError` is returned.

One thing I'm confused about — I thought that adding support for typos would increase our coverage, since previously we hadn't been covering that part of the plotting functions. But if I generate a coverage report, it looks like it still doesn't "see" that we _are_ testing those lines. Do you know what's going on?