### PR TITLE
adding Theano-PyMC==1.0.5 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Theano==1.0.5
+Theano-PyMC==1.0.5 
 pymc3==3.9.3
 arviz==0.11.1
 scikit-learn


### PR DESCRIPTION
fixes #85

pins Theano-PyMC to 1.0.5, the same version that Theano is already pinned to. This is helpful for using PyEI in google colabs, where a later version of Theano-PyMC currently would be installed and can cause trouble