### PR TITLE
Adding histograms option for precinct-level plots

### DIFF
--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -132,6 +132,20 @@ def plot_single_ridgeplot(
     ax.plot(x, group2_y + trans, color="black", linewidth=1, zorder=z_init + 3)
 
 
+def plot_single_histogram(
+    ax,
+    group1_pref,
+    group2_pref,
+    colors,  # pylint: disable=redefined-outer-name
+    z_init,
+    trans,
+    overlap=1.3,
+):
+    # bins = np.linspace(0, 1.0, num=20)
+    ax.hist(group1_pref, bottom=trans, zorder=z_init + 1, color=colors[0])
+    ax.hist(group2_pref, bottom=trans, zorder=z_init + 1, color=colors[1])
+
+
 def plot_precincts(
     voting_prefs_group1,
     voting_prefs_group2,

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -133,14 +133,29 @@ def plot_single_ridgeplot(
 
 
 def plot_single_histogram(
-    ax,
-    group1_pref,
-    group2_pref,
-    colors,  # pylint: disable=redefined-outer-name
-    z_init,
-    trans,
-    overlap=1.3,
+    ax, group1_pref, group2_pref, colors, z_init, trans  # pylint: disable=redefined-outer-name
 ):
+    """Helper function for plot_precincts that plots a single precinct histogram(s)
+       (i.e.,for a single precinct for a given candidate.)
+
+    Parameters
+    ----------
+    ax : matplotlib axis object
+    group1_pref : array
+        The estimates for the support for the candidate among
+        Group 1 (array of floats, expected to be between 0 and 1)
+    group2_pref : array
+        The estimates for the support for the candidate among
+        Group 2 (array of floats, expected to be between 0 and 1)
+    colors : array
+        The (ordered) names of colors to use to fill ridgeplots
+    z_init : float
+        The initial value for the z-order (helps determine
+        how plots get drawn over one another)
+    trans
+        The y-translation for this plot
+    """
+
     bins = np.linspace(0, 1.0, num=20)
     weights, bins = np.histogram(group1_pref, bins=bins)
     weights = weights / weights.max()

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -141,9 +141,29 @@ def plot_single_histogram(
     trans,
     overlap=1.3,
 ):
-    # bins = np.linspace(0, 1.0, num=20)
-    ax.hist(group1_pref, bottom=trans, zorder=z_init + 1, color=colors[0])
-    ax.hist(group2_pref, bottom=trans, zorder=z_init + 1, color=colors[1])
+    bins = np.linspace(0, 1.0, num=20)
+    weights, bins = np.histogram(group1_pref, bins=bins)
+    weights = weights / weights.max()
+    ax.hist(
+        bins[:-1],
+        bins=bins,
+        weights=weights,
+        bottom=trans,
+        zorder=z_init + 1,
+        color=colors[0],
+        edgecolor="black",
+    )
+    weights, bins = np.histogram(group2_pref, bins=bins)
+    weights = weights / weights.max()
+    ax.hist(
+        bins[:-1],
+        bins=bins,
+        weights=weights,
+        bottom=trans,
+        zorder=z_init + 1,
+        color=colors[1],
+        edgecolor="black",
+    )
 
 
 def plot_precincts(
@@ -153,6 +173,7 @@ def plot_precincts(
     candidate,
     precinct_labels=None,
     show_all_precincts=False,
+    plot_as_histograms=False,
     ax=None,
 ):
     """Ridgeplots of sampled voting preferences for each precinct
@@ -175,6 +196,8 @@ def plot_precincts(
         precincts. If show_all_precincts is True, we plot the ridgeplots
         for all precincts (i.e., one ridgeplot for every column in the
         voting_prefs matrices)
+    plot_as_histograms : bool, optional
+        Default: False If true, plot with histograms instead of kdes
     ax : Matplotlib axis object or None, optional
         Default=None
 
@@ -207,7 +230,10 @@ def plot_precincts(
     for idx, (group1, group2) in enumerate(iterator, 0):
         ax.plot([0], [idx])
         trans = ax.convert_yunits(idx)
-        plot_single_ridgeplot(ax, group1, group2, colors, 4 * (N - idx), trans)
+        if plot_as_histograms:
+            plot_single_histogram(ax, group1, group2, colors, 4 * (N - idx), trans)
+        else:
+            plot_single_ridgeplot(ax, group1, group2, colors, 4 * (N - idx), trans)
     for i in range(legend_space):
         # add `legend_space` number of lines to the top of the plot for legend
         ax.plot([0], [N + i])

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -959,7 +959,9 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
             axes=axes,
         )
 
-    def precinct_level_plot(self, ax=None, show_all_precincts=False, precinct_names=None):
+    def precinct_level_plot(
+        self, ax=None, show_all_precincts=False, precinct_names=None, plot_as_histograms=False
+    ):
         """Ridgeplots for precincts
         Optional arguments:
         ax                  :  matplotlib axes object
@@ -968,6 +970,8 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
         precinct_names      :  Labels for each precinct (if not supplied, by
                                default we label each precinct with an integer
                                label, 1 to n)
+        plot_as_histograms : bool, optional. Default is false. If true, plot
+                                with histograms instead of kdes
         """
         voting_prefs_group1 = self.sim_trace.get_values("b_1")
         voting_prefs_group2 = self.sim_trace.get_values("b_2")
@@ -983,5 +987,6 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
             candidate=self.candidate_name,
             precinct_labels=precinct_names,
             show_all_precincts=show_all_precincts,
+            plot_as_histograms=plot_as_histograms,
             ax=ax,
         )

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -99,18 +99,18 @@ def truncated_normal_asym(
 
         mu_i = tn_mean_upper * group_fraction + tn_mean_lower * (1 - group_fraction)
         w_i = pm.Deterministic(
-            "w_i", sigma_upper ** 2 * group_fraction + sigma_12 * (1 - group_fraction)
+            "w_i", sigma_upper**2 * group_fraction + sigma_12 * (1 - group_fraction)
         )
         sigma_i_sq = pm.Deterministic(
             "sigma_i_sq",
-            sigma_lower ** 2
-            + 2 * (sigma_12 - sigma_lower ** 2) * group_fraction
-            + (sigma_upper * 2 + sigma_lower ** 2 - 2 * sigma_12) * group_fraction ** 2,
+            sigma_lower**2
+            + 2 * (sigma_12 - sigma_lower**2) * group_fraction
+            + (sigma_upper * 2 + sigma_lower**2 - 2 * sigma_12) * group_fraction**2,
         )
 
-        votes_frac_mean = mu_i + w_i * (upper_b - tn_mean_upper) / (sigma_upper ** 2)
+        votes_frac_mean = mu_i + w_i * (upper_b - tn_mean_upper) / (sigma_upper**2)
         votes_frac_var = pm.Deterministic(
-            "votes_frac_var", sigma_i_sq - w_i ** 2 / (sigma_upper ** 2)
+            "votes_frac_var", sigma_i_sq - w_i**2 / (sigma_upper**2)
         )
 
         votes_frac_l_bound = group_fraction * upper_b


### PR DESCRIPTION
Histograms are now an alternative to kdes for the precinct ridgeplots. You can pass `plot_as_histograms=True` to `plot_utils.plot_precincts()` or `TwoByTwoEI.precinct_level_plot()` to show the result as a set of histograms instead of as kdes. Kdes remain the default option.