### PR TITLE
Shape comments and arguments

### DIFF
--- a/pyei/r_by_c_models.py
+++ b/pyei/r_by_c_models.py
@@ -58,6 +58,7 @@ def ei_multinom_dirichlet(group_fractions, votes_fractions, precinct_pops, lmbda
             n=precinct_pops,
             p=theta,
             observed=votes_count_obs,
+            shape=(num_precincts, num_cols),
         )  # num_precincts x c
     return model
 
@@ -114,5 +115,6 @@ def ei_multinom_dirichlet_modified(
             n=precinct_pops,
             p=theta,
             observed=votes_count_obs,
+            shape=(num_precincts, num_cols),
         )  # num_precincts x c
     return model

--- a/pyei/r_by_c_models.py
+++ b/pyei/r_by_c_models.py
@@ -58,8 +58,7 @@ def ei_multinom_dirichlet(group_fractions, votes_fractions, precinct_pops, lmbda
             n=precinct_pops,
             p=theta,
             observed=votes_count_obs,
-            shape=(num_precincts, num_rows),
-        )  # num_precincts x r
+        )  # num_precincts x c
     return model
 
 
@@ -115,6 +114,5 @@ def ei_multinom_dirichlet_modified(
             n=precinct_pops,
             p=theta,
             observed=votes_count_obs,
-            shape=(num_precincts, num_rows),
-        )  # num_precincts x r
+        )  # num_precincts x c
     return model

--- a/test/test_r_by_c_plotting.py
+++ b/test/test_r_by_c_plotting.py
@@ -26,6 +26,7 @@ def example_r_by_c_data():
         "candidate_names": candidate_names,
     }
 
+
 @pytest.fixture(scope="session")
 def example_r_by_c_data_asym():
     """trimmed santa clara dataset with r not equal to c"""

--- a/test/test_r_by_c_plotting.py
+++ b/test/test_r_by_c_plotting.py
@@ -26,6 +26,24 @@ def example_r_by_c_data():
         "candidate_names": candidate_names,
     }
 
+@pytest.fixture(scope="session")
+def example_r_by_c_data_asym():
+    """trimmed santa clara dataset with r not equal to c"""
+    sc_data = data.Datasets.Santa_Clara.to_dataframe()
+    sc_data = sc_data.iloc[:10, :]
+    precinct_pops = np.array(sc_data["total2"])
+    votes_fractions = np.array(sc_data[["pct_for_hardy2", "pct_for_kolstad2", "pct_for_nadeem2"]]).T
+    candidate_names = ["Hardy", "Kolstad", "Nadeem"]
+    group_fractions = np.array(sc_data[["pct_asian_vote", "pct_non_asian_vote"]]).T
+    demographic_group_names = ["asian", "non_asian"]
+    return {
+        "group_fractions": group_fractions,
+        "votes_fractions": votes_fractions,
+        "precinct_pops": precinct_pops,
+        "demographic_group_names": demographic_group_names,
+        "candidate_names": candidate_names,
+    }
+
 
 def example_r_by_c_ei(example_r_by_c_data, model_name):  # pylint: disable=redefined-outer-name
     """Run this to generate an EI instance"""
@@ -44,11 +62,14 @@ def example_r_by_c_ei(example_r_by_c_data, model_name):  # pylint: disable=redef
 
 
 @pytest.fixture(scope="session")
-def two_r_by_c_ei_runs(example_r_by_c_data):  # pylint: disable=redefined-outer-name
+def two_r_by_c_ei_runs(
+    example_r_by_c_data, example_r_by_c_data_asym
+):  # pylint: disable=redefined-outer-name
     """use the EI Factory to fix two EI instances for our tests"""
     example_ei_r_by_c_1 = example_r_by_c_ei(example_r_by_c_data, "multinomial-dirichlet")
     example_ei_r_by_c_2 = example_r_by_c_ei(example_r_by_c_data, "multinomial-dirichlet-modified")
-    return [example_ei_r_by_c_1, example_ei_r_by_c_2]
+    example_ei_r_by_c_asym = example_r_by_c_ei(example_r_by_c_data_asym, "multinomial-dirichlet")
+    return [example_ei_r_by_c_1, example_ei_r_by_c_2, example_ei_r_by_c_asym]
 
 
 def test_ei_r_by_c_summary(two_r_by_c_ei_runs):  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
Fixes #91 

Fixing the shape argument (and associated comments) for the observed multinomial draws of votes (correct shape is num_precincts x num_columns) in the r by c models. Note: I'm not totally sure why this argument is necessary, since this is the observed variable (so has access to the shape of the observations), and it seemed to get ignored in previous runs. However, omitting the shape argument entirely seems to leads to errors when using the latest version of pymc3 (but not in version 3.9.3). This PR also updates the r by c tests to include an example with r not equal to c.