### PR TITLE
Fix COC report bug

### DIFF
--- a/pyei/r_by_c.py
+++ b/pyei/r_by_c.py
@@ -11,7 +11,6 @@ TODO: Refactor to integrate with two_by_two
 import warnings
 import pymc3 as pm
 import numpy as np
-from copy import copy
 from .plot_utils import (
     plot_boxplots,
     plot_kdes,

--- a/pyei/r_by_c.py
+++ b/pyei/r_by_c.py
@@ -11,6 +11,7 @@ TODO: Refactor to integrate with two_by_two
 import warnings
 import pymc3 as pm
 import numpy as np
+from copy import copy
 from .plot_utils import (
     plot_boxplots,
     plot_kdes,
@@ -675,7 +676,7 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         if non_candidate_names is None:
             non_candidate_names = []
         non_cand_idxs = [self.candidate_names.index(n) for n in non_candidate_names]
-        cand_names = list(set(self.candidate_names) - set(non_candidate_names))
+        cand_names = [c for c in self.candidate_names if c not in non_candidate_names]
         sampled_voting_prefs = np.delete(self.sampled_voting_prefs, non_cand_idxs, axis=2)
 
         for row in range(self.num_groups_and_num_candidates[0]):


### PR DESCRIPTION
This fix keeps the candidate name order invariant when dropping the "None" candidate, if there is one. With the older code, the `set()` function would nondeterministically reorder the candidate names which could sometimes give incorrect answers.