### PR TITLE
Quick fixes

### DIFF
--- a/pyei/greiner_quinn_gibbs_sampling.py
+++ b/pyei/greiner_quinn_gibbs_sampling.py
@@ -530,7 +530,6 @@ def get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
                     / precinct_pops[i]
                 )
                 prop_for_binom = vote_counts[i, c] / precinct_pops[i]
-                # samp = st.binom.rvs(count_for_binom, prop_for_binom)
                 samp = np.random.binomial(count_for_binom, prop_for_binom)
 
                 samp = min(samp, vote_counts_remaining[i, c])

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -722,7 +722,7 @@ def plot_kdes(sampled_voting_prefs, group_names, candidate_names, plot_by="candi
         axes[middle_plot].legend(bbox_to_anchor=(1, 1), loc="upper left", prop={"size": 12})
     else:
         ax.legend(prop={"size": 12})
-    return ax
+    return axes
 
 
 def plot_conf_or_credible_interval(intervals, group_names, candidate_name, title, ax=None):

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -1,8 +1,6 @@
 """
 Models and fitting for 2x2 methods
 
-TODO: Checks for wakefield model
-TODO: Wakefield model with normal prior
 """
 
 import warnings
@@ -186,8 +184,6 @@ def ei_beta_binom_model_modified(
 
         theta = group_fraction * b_1 + (1 - group_fraction) * b_2
         pm.Binomial("votes_count", n=precinct_pops, p=theta, observed=votes_count_obs)
-        # pm.Deterministic("voting_prefs_gp1", (b_1 * precinct_pops).sum() / tot_pop)
-        # pm.Deterministic("voting_prefs_gp2", (b_2 * precinct_pops).sum() / tot_pop)
 
     return model
 
@@ -259,7 +255,6 @@ def log_binom_sum(lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b_2_curr, 
     # given group for given candidate within precinct i (unobserved)
     votes_within_group_count = at.arange(lower, upper)
     component_for_current_precinct = pm.math.logsumexp(
-        # The `rv.logp(x)` method was removed. Instead use `pm.logp(rv, x)`.`
         pm.logp(pm.Binomial.dist(n0_curr, b_1_curr), votes_within_group_count)
         + pm.logp(pm.Binomial.dist(n1_curr, b_2_curr), obs_vote - votes_within_group_count)
     )

--- a/test/test_greiner_quinn.py
+++ b/test/test_greiner_quinn.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 import scipy.stats as st
 
+
 from pyei import data
 from pyei.r_by_c import RowByColumnEI
 from pyei.greiner_quinn_gibbs_sampling import (
@@ -12,6 +13,7 @@ from pyei.greiner_quinn_gibbs_sampling import (
     theta_to_omega,
     greiner_quinn_gibbs_sample,
 )
+from pyei.distribution_utils import non_central_hypergeometric_sample
 
 
 @pytest.fixture(scope="session")
@@ -59,9 +61,12 @@ def test_get_initial_internal_count_sample(
     group_counts = example_r_by_c_data_asym["group_counts"]
     precinct_pops = example_r_by_c_data_asym["precinct_pops"]
     samp = get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops)
+    samp_py = get_initial_internal_count_sample.py_func(group_counts, vote_counts, precinct_pops)
 
     assert np.all(samp.sum(axis=2) - group_counts == 0)  # sample respects given group counts
     assert np.all(samp.sum(axis=1) - vote_counts == 0)  # sample respects given vote counts
+    assert np.all(samp_py.sum(axis=2) - group_counts == 0)  # sample respects given group counts
+    assert np.all(samp_py.sum(axis=1) - vote_counts == 0)  # sample respects given vote counts
 
 
 def test_theta_to_omega():
@@ -119,3 +124,11 @@ def test_pyei_greiner_quinn_gibbs(
         num_samples=5,
         burnin=1,
     )
+
+
+def test_non_central_hypergeometric_sample():
+    samp = non_central_hypergeometric_sample.py_func(10, 5, 7, 1)
+    assert samp >= 2
+    assert samp <= 10
+    samp2 = non_central_hypergeometric_sample.py_func(10, 10, 7, 1)
+    assert samp2 <= 10

--- a/test/test_r_by_c_plotting.py
+++ b/test/test_r_by_c_plotting.py
@@ -256,3 +256,8 @@ def test_plot_polarization_kde(two_r_by_c_ei_runs):  # pylint: disable=redefined
             groups, candidate, threshold=0.4, percentile=95, show_threshold=True
         )
     print("done")
+
+
+def test_plot_margin_kde(two_r_by_c_ei_runs):  # pylint: disable=redefined-outer-name
+    example_r_by_c_ei = two_r_by_c_ei_runs[0]  # pylint: disable=redefined-outer-name
+    example_r_by_c_ei.plot_margin_kde("ind", ["Hardy", "Nadeem"], threshold=0.1)


### PR DESCRIPTION
Adding tests so that the functions that are decoraged w/ numba's jit are also tested separately, so that the test coverage reports aren't underreporting test coverage as much (the coverage reports don't mark the jit-compiled functions as having been run).  (Closes #101)

Also, adds a fix so that `plot_utils.plot_kdes()` returns the full list of Axes for the plot, not just one set.

