### PR TITLE
Incrementing version number

### DIFF
--- a/pyei/__init__.py
+++ b/pyei/__init__.py
@@ -1,5 +1,5 @@
 """A package for rpv and ecological inference"""
-__version__ = "0.1.4"
+__version__ = "1.0.0"
 from .two_by_two import *
 from .goodmans_er import *
 from .plot_utils import *


### PR DESCRIPTION
Moving to 1.0.0 -- a big bump to indicate that a few things in the API have changed since the last release, which didn't use pymc v4. The biggest change for users would be if they are interacting with the samples as InferenceData objects, when they used to be just numpy arrays.