### PR TITLE
minor updates to make compatible with requirement updates

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,8 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=bad-continuation,
-        fixme,
+disable=fixme,
         no-else-return,
         too-many-lines
 
@@ -129,13 +128,6 @@ max-line-length=100
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/pyei/greiner_quinn_gibbs_sampling.py
+++ b/pyei/greiner_quinn_gibbs_sampling.py
@@ -409,7 +409,6 @@ def sample_theta(internal_cell_counts_samp, theta_prev, omega_prev, mu_samp, Sig
 
     unif_samp = st.uniform.rvs(size=1)
     if unif_samp < acc_prob:
-
         return theta_proposed
     else:
         return theta_prev
@@ -478,7 +477,7 @@ def sample_internal_cell_counts(theta_samp, prev_internal_counts_samp):
     return prev_internal_counts_samp
 
 
-@njit(parallel=True)
+@njit(parallel=True, nopython=False)
 def get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
     """
     Sets an initial value of internal counts that is compatible with the
@@ -530,7 +529,7 @@ def get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
                     / precinct_pops[i]
                 )
                 prop_for_binom = vote_counts[i, c] / precinct_pops[i]
-                samp = np.random.binomial(count_for_binom, prop_for_binom)
+                samp = np.random.binomial(n=int(count_for_binom), p=int(prop_for_binom))
 
                 samp = min(samp, vote_counts_remaining[i, c])
                 samp = min(samp, group_counts_remaining[i, r])

--- a/pyei/io_utils.py
+++ b/pyei/io_utils.py
@@ -65,7 +65,7 @@ def to_netcdf(ei_object, filepath):
         mode = "a"
         for attr in ["demographic_group_fractions", "votes_fractions"]:  # array atts
             data = xr.DataArray(getattr(ei_object, attr), name=attr)
-            data.to_netcdf(filepath, mode=mode, group=attr)
+            data.to_netcdf(filepath, mode=mode, group=attr, engine="netcdf4")
             data.close()
 
 

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -330,7 +330,6 @@ def plot_boxplots(
     fig.subplots_adjust(hspace=1)
 
     for plot_idx in range(num_plots):
-
         samples_df = pd.DataFrame(
             {legend[i]: sampled_voting_prefs[:, i, plot_idx] for i in range(num_boxes_per_plot)}
         )
@@ -391,9 +390,9 @@ def plot_summary(
     sns.despine(ax=ax_hist)
     sns.despine(ax=ax_box, left=True)
     # plot custom boxplot, with two boxplots in the same row
-    plot_props = dict(fliersize=5, linewidth=2, whis=[2.5, 97.5])
-    flier1_props = dict(marker="o", markerfacecolor=colors[0], alpha=0.5)
-    flier2_props = dict(marker="d", markerfacecolor=colors[1], alpha=0.5)
+    plot_props = {"fliersize": 5, "linewidth": 2, "whis": [2.5, 97.5]}
+    flier1_props = {"marker": "o", "markerfacecolor": colors[0], "alpha": 0.5}
+    flier2_props = {"marker": "d", "markerfacecolor": colors[1], "alpha": 0.5}
     sns.boxplot(
         x=sampled_voting_prefs[:, 0, 0],
         orient="h",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jax
 numpyro
 jaxlib
 numba
+netCDF4

--- a/test/test_goodmans_er.py
+++ b/test/test_goodmans_er.py
@@ -152,6 +152,5 @@ def test_goodman_er_bayes_bounds(goodmans_er_bayes_examples):
 
 
 def test_goodman_er_bayes_plot(goodmans_er_bayes_examples):
-
     ax = goodmans_er_bayes_examples["bayes_goodman_ei_weighted"].plot()
     assert ax is not None

--- a/test/test_greiner_quinn.py
+++ b/test/test_greiner_quinn.py
@@ -85,7 +85,6 @@ def test_theta_to_omega():
 def test_greiner_quinn_gibbs_sample(
     example_r_by_c_data_asym,
 ):  # pylint: disable=redefined-outer-name
-
     r = example_r_by_c_data_asym["group_counts"].shape[1]
     c = example_r_by_c_data_asym["vote_counts"].shape[1]
     print(r, c)


### PR DESCRIPTION
This is a set of miscellaneous updates to make sure all the tests run with recent versions of the requirements and dev requirements (especially updates to the linter and formatter, but also adding a netCDF4 requirement to support the use of groups in the functionality for saving outputs, and and making sure the quinn griener sampling still work with numba).