### PR TITLE
Add autopublish workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,31 +1,48 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: Python package
-
-on: [push, pull_request]
-
+name: unittests & auto-publish
+on: [push, workflow_dispatch]
 jobs:
-  build:
+  pytest-job:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
+    timeout-minutes: 30
+
+    concurrency: ${{ github.workflow }}-${{ github.ref }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - run: pip --version
+    - run: pip install .
+    - run: pip install -r requirements-dev.txt
+    - run: pip freeze
+    - name: Run linters
+      run: |
+        ./scripts/lint.sh
+    - name: Test with pytest
+      run: |
+        ./scripts/test.sh
+
+  # Auto-publish when version is increased
+  publish-job:
+    # Only try to publish if:
+    # * Repo is self (prevents running from forks)
+    # * Branch is `main`
+    if: |
+      github.repository == 'mggg/ecological-inference'
+      && github.ref == 'refs/heads/main'
+    needs: pytest-job  # Only publish after tests are successful
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
-      - name: Run linters
-        run: |
-          ./scripts/lint.sh
-      - name: Test with pytest
-        run: |
-          ./scripts/test.sh
+    # Publish the package (if local `__version__` > pip version)
+    - uses: etils-actions/pypi-auto-publish@v1
+      with:
+        pypi-token: ${{ secrets.PYPI_API_TOKEN }}
+        gh-token: ${{ secrets.GITHUB_TOKEN }}
+        parse-changelog: false
+        pkg-name: pyei


### PR DESCRIPTION
This should allow a PyPI release when `pyei.__version__` is greater than the latest version at https://pypi.org/project/pyei/. I also updated some of the github actions to more recent ones.

Note that this requires 
1. creating a security token at https://pypi.org/manage/project/pyei/settings/, and then 
2. going to https://github.com/mggg/ecological-inference/settings/secrets/actions and adding this key as a secret named "PYPI_API_TOKEN"

I think that's it! But it might require some futzing. In particular, the action only runs when you merge to main and update the version number, so we can't really tell if it worked until you merge this, do those two steps, and then bump the version number.

For what it is worth, both of [bayeux](https://github.com/jax-ml/bayeux) and [ridge_map](https://github.com/ColCarroll/ridge_map) use this action. 

