### PR TITLE
Upgrade pymc, make new release.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ confidence=
 # --disable=W".
 disable=fixme,
         no-else-return,
-        too-many-lines
+        too-many-lines,
+        similarities
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -483,6 +484,9 @@ preferred-modules=
 
 
 [DESIGN]
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=10
 
 # Maximum number of arguments for function / method.
 max-args=10

--- a/pyei/__init__.py
+++ b/pyei/__init__.py
@@ -1,6 +1,6 @@
 """A package for rpv and ecological inference"""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 from .two_by_two import *
 from .goodmans_er import *
 from .plot_utils import *

--- a/pyei/r_by_c.py
+++ b/pyei/r_by_c.py
@@ -9,7 +9,7 @@ TODO: Refactor to integrate with two_by_two
 """
 
 import warnings
-from pymc import sampling_jax
+import pymc as pm
 import numpy as np
 from .plot_utils import (
     plot_boxplots,
@@ -200,8 +200,11 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
                 "multinomial-dirichlet",
             ]:  # for models whose sampling is w/ pycm
                 with self.sim_model:  # pylint: disable=not-context-manager
-                    self.sim_trace = sampling_jax.sample_numpyro_nuts(
-                        target_accept=target_accept, tune=tune, **other_sampling_args
+                    self.sim_trace = pm.sample(
+                        target_accept=target_accept,
+                        tune=tune,
+                        nuts_sampler="numpyro",
+                        **other_sampling_args,
                     )
             elif self.model_name == "greiner-quinn":
                 self.sim_trace = pyei_greiner_quinn_sample(

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -5,7 +5,6 @@ Models and fitting for 2x2 methods
 
 import warnings
 import pymc as pm
-from pymc import sampling_jax
 import numpy as np
 import pytensor.tensor as at
 import pytensor
@@ -847,9 +846,10 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
                         **other_sampling_args,
                     )
                 else:
-                    self.sim_trace = sampling_jax.sample_numpyro_nuts(
+                    self.sim_trace = pm.sample(
                         target_accept=target_accept,
                         tune=tune,
+                        nuts_sampler="numpyro",
                         **other_sampling_args,
                     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymc >= 5.10.0
+pymc >= 5.18.0
 arviz
 scikit-learn
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
         with codecs.open(REQUIREMENTS_FILE, "r", encoding="utf-8") as buff:
             return buff.read().splitlines()
     except:
-        return """pymc >= 5.10.0
+        return """pymc >= 5.18.0
 arviz
 scikit-learn
 matplotlib


### PR DESCRIPTION
`sampling_jax` was deprecated a few months ago, and I think this is the minimal change that'll get it working again. It looks like pylint has also changed a bit, so there are some changes to the configuration so that linting continues to pass.

I also think the version bump will automatically push a new release to pypi!