### PR TITLE
Bump pymc version to allow numpy 2+

### DIFF
--- a/pyei/__init__.py
+++ b/pyei/__init__.py
@@ -1,6 +1,6 @@
 """A package for rpv and ecological inference"""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 from .two_by_two import *
 from .goodmans_er import *
 from .plot_utils import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymc >= 5.18.0
+pymc >= 5.21.0
 arviz
 scikit-learn
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
         with codecs.open(REQUIREMENTS_FILE, "r", encoding="utf-8") as buff:
             return buff.read().splitlines()
     except:
-        return """pymc >= 5.18.0
+        return """pymc >= 5.21.0
 arviz
 scikit-learn
 matplotlib


### PR DESCRIPTION
I think this is all that is needed to allow numpy 2+... in fact, I think that just `pip install -U` might have worked already, but this will enforce that a recent enough pymc is installed to allow new numpy to work.