### PR TITLE
refactor: improve code organization with private function naming and absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2025-09-25
+
+### Added
+- Better code organization with proper private function naming
+
+### Changed
+- **BREAKING**: Renamed internal helper functions to follow Python private function conventions (leading underscore)
+- **BREAKING**: Converted all relative imports to absolute imports within the package
+- **BREAKING**: Removed `__all__` specifiers from all module files
+- Improved code maintainability and organization
+
+### Migration Required
+- Update any direct imports of renamed private functions
+- Replace wildcard imports with explicit imports
+- See [MIGRATION_NOTES.md](MIGRATION_NOTES.md) for detailed migration instructions
+
+## [1.2.0] - 2025-09-11
+
+### Changed
+- Migrated from Docker-based development to `uv`-based workflow
+- Updated build system from `setup.py` to `pyproject.toml`
+- Consolidated CI/CD workflows into a single file
+- Updated CI/CD to test against Python 3.11, 3.12, and 3.13
+
+### Removed
+- Docker support and related files
+- `setup.py` and `requirements.txt` files
+- Separate GitHub Actions workflow files
+
+

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -1,77 +1,114 @@
-# Migration Notes: Docker → uv + Virtual Environments
+# Migration Notes
 
-This document explains the modernization changes made to the development workflow.
+This document describes breaking changes and migration instructions for the PyEI package.
 
-## Changes Made
+## Version 1.2.0 - Code Refactoring (Breaking Changes)
 
-### Replaced Docker with uv Virtual Environments
-- **Removed**: `Dockerfile` and Docker-based workflow
-- **Added**: `uv`-based virtual environment workflow
-- **Updated**: Python requirement from 3.10 to 3.11
+### Overview
+This release includes significant internal refactoring to improve code organization and maintainability. While the public API remains largely unchanged, some internal functions have been renamed and import patterns have been updated.
 
-### Modernized Package Management
-- **Removed**: `setup.py` (replaced with `pyproject.toml`)
-- **Replaced**: `requirements.txt` and `requirements-dev.txt` → dependency groups in `pyproject.toml`
-- **Updated**: Build system from `setuptools` to `hatchling`
-- **Added**: `uv.lock` for exact reproducibility
-- **Replaced**: `pip` → `uv` (faster, more reliable)
-- **Replaced**: `black` + `pylint` → `ruff` (faster, unified)
+### Breaking Changes
 
-### Consolidated CI/CD Workflow
-- **Consolidated**: Multiple workflow files → single `ci.yml`
-- **Updated**: Uses Makefile targets for consistency
-- **New structure**:
-  - Linting runs on all commits (push and PR)
-  - Testing runs only on PRs (non-draft only)
-  - Publishing runs only on pushes to main
+#### 1. Private Function Renaming
+Several internal helper functions have been renamed to follow Python conventions for private functions (leading underscore).
 
-## Command Equivalents
+**Affected Functions:**
+- `size_ticks()` → `_size_ticks()`
+- `size_yticklabels()` → `_size_yticklabels()`
+- `plot_single_ridgeplot()` → `_plot_single_ridgeplot()`
+- `plot_single_histogram()` → `_plot_single_histogram()`
+- `log_binom_sum()` → `_log_binom_sum()`
+- `binom_conv_log_p()` → `_binom_conv_log_p()`
+- `goodmans_er_bayes_model()` → `_goodmans_er_bayes_model()`
+- `goodmans_er_bayes_pop_weighted_model()` → `_goodmans_er_bayes_pop_weighted_model()`
+- `r_function()` → `_r_function()`
+- `sample_low_to_high()` → `_sample_low_to_high()`
+- `sample_high_to_low()` → `_sample_high_to_low()`
+- `sample_Sigma()` → `_sample_Sigma()`
+- `sample_mu()` → `_sample_mu()`
+- `proposal_dist_generate_sample()` → `_proposal_dist_generate_sample()`
+- `log_unnormalized_pdf()` → `_log_unnormalized_pdf()`
+- `theta_to_omega()` → `_theta_to_omega()`
+- `sample_theta()` → `_sample_theta()`
+- `omega_to_theta()` → `_omega_to_theta()`
+- `sample_internal_cell_counts()` → `_sample_internal_cell_counts()`
+- `get_initial_internal_count_sample()` → `_get_initial_internal_count_sample()`
 
-| Old Command | New Command |
-|-------------|-------------|
-| `make build` | `make setup` |
-| `make test` (Docker) | `make test` (uv) |
-| `make lint` (Docker) | `make lint` (uv) |
-| `make bash` (Docker) | `source .venv/bin/activate` |
-| `pip install -e .` | `uv pip install -e .` |
-| `pip install -r requirements-dev.txt` | `uv pip install -e ".[dev]"` |
+**Migration Required:** If you were directly importing or calling any of these functions, update your code to use the new names with leading underscores.
 
-## For Contributors
+**Example:**
+```python
+# Before (v1.1.x)
+from pyei.plot_utils import size_ticks
+size_ticks(ax, "x")
 
-### Development Setup
-```bash
-make setup          # Create venv and install dev dependencies
-source .venv/bin/activate  # Activate virtual environment
-make test           # Run tests
-make lint           # Run linting
-make format         # Format code
+# After (v1.2.0+)
+from pyei.plot_utils import _size_ticks
+_size_ticks(ax, "x")
 ```
 
-### Direct uv Commands
-```bash
-uv run pytest       # Run tests
-uv run ruff check   # Lint code
-uv run ruff format  # Format code
-uv run mypy pyei    # Type checking
+#### 2. Import Pattern Changes
+All relative imports within the package have been converted to absolute imports.
+
+**Migration Required:** If you were copying import patterns from the PyEI source code, update them to use absolute imports.
+
+**Example:**
+```python
+# Before (internal PyEI code)
+from .plot_utils import plot_kdes
+from .r_by_c_models import ei_multinom_dirichlet
+
+# After (internal PyEI code)
+from pyei.plot_utils import plot_kdes
+from pyei.r_by_c_models import ei_multinom_dirichlet
 ```
 
-### Dependency Management
-```bash
-uv pip list         # Show installed packages
-uv lock --upgrade   # Update lock file
+#### 3. Removed `__all__` Specifiers
+All `__all__` specifiers have been removed from module files.
+
+**Impact:** This affects `from module import *` statements. While not recommended, if you were using wildcard imports, you may need to import specific functions explicitly.
+
+**Example:**
+```python
+# Before (if using wildcard imports)
+from pyei.plot_utils import *
+# This would import only functions listed in __all__
+
+# After (recommended approach)
+from pyei.plot_utils import plot_kdes, plot_summary
+# Import only what you need explicitly
 ```
 
-## Publishing
+### Non-Breaking Changes
 
-To publish a new version:
-1. Update the version in `pyproject.toml`
-2. Commit and push to main
-3. The CI/CD workflow automatically publishes to PyPI
+#### 1. Public API Unchanged
+All public classes and methods remain unchanged:
+- `TwoByTwoEI`
+- `TwoByTwoEIBaseBayes`
+- `GoodmansER`
+- `GoodmansERBayes`
+- `RowByColumnEI`
+- `Datasets`
 
+#### 2. Functionality Preserved
+All existing functionality works exactly the same way. Only internal implementation details have changed.
 
-## Backward Compatibility
+### Migration Checklist
 
-- All functionality is preserved, just modernized
-- Virtual environments ensure consistent environments across machines
-- No Docker dependency required
-- Same development experience, better performance
+- [ ] Search your codebase for any direct imports of the renamed private functions
+- [ ] Update function calls to use the new names with leading underscores
+- [ ] Replace any wildcard imports (`from module import *`) with explicit imports
+- [ ] Test your code to ensure it still works as expected
+
+### Need Help?
+
+If you encounter issues during migration:
+1. Check this migration guide for the specific function you're using
+2. Look at the updated PyEI source code for correct import patterns
+3. Open an issue on GitHub if you need assistance
+
+### Future Considerations
+
+- Private functions (those with leading underscores) are considered internal implementation details
+- Future versions may change or remove private functions without notice
+- Always use public APIs when possible for better compatibility across versions

--- a/pyei/data.py
+++ b/pyei/data.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 
 import pandas as pd
 
-__all__ = ["Datasets"]
-
 
 @dataclass
 class _DataSet:

--- a/pyei/distribution_utils.py
+++ b/pyei/distribution_utils.py
@@ -1,6 +1,5 @@
 # pylint: disable-all
-"""
-Port of R code for Noncentral Hypergeometric distribution
+"""Port of R code for Noncentral Hypergeometric distribution
 adapted from R code published in conjunction with:
 Liao, J.G. And Rosen, O. (2001) Fast and Stable Algorithms for Computing and
 Sampling from the Noncentral Hypergeometric Distribution.  The American
@@ -8,21 +7,21 @@ Statistician 55, 366-369.
 
 Used in Greiner-Quinn method Gibbs sampler
 """
+
 import math
+
 import numpy as np
 from numba import jit
 
 
 @jit
-def r_function(n1, n2, m1, psi, i):
-    """
-    The function r defined in Liao and Rosen 2001
-    """
+def _r_function(n1, n2, m1, psi, i):
+    """The function r defined in Liao and Rosen 2001"""
     return (n1 - i + 1) * (m1 - i + 1) / (i * (n2 - m1 + i)) * psi
 
 
 @jit
-def sample_low_to_high(lower, ran, pi, shift, uu):
+def _sample_low_to_high(lower, ran, pi, shift, uu):
     for i in range(lower, uu + 1):
         if ran <= pi[i + shift]:
             return i
@@ -30,7 +29,7 @@ def sample_low_to_high(lower, ran, pi, shift, uu):
 
 
 @jit
-def sample_high_to_low(upper, ran, pi, shift, ll):
+def _sample_high_to_low(upper, ran, pi, shift, ll):
     for i in range(upper, ll - 1, -1):
         if ran <= pi[i + shift]:
             return i
@@ -50,7 +49,6 @@ def non_central_hypergeometric_sample(n1, n2, m1, psi):
     this the nchg distribution governs with parameters n1, n2, pis, m1
     is the distribution for y1 | y1 + y2 = m1
     """
-
     ll = max(0, m1 - n2)
     uu = min(n1, m1)
 
@@ -68,11 +66,11 @@ def non_central_hypergeometric_sample(n1, n2, m1, psi):
     pi = np.ones(uu - ll + 1, dtype=np.float32)
 
     if mode < uu:
-        r = r_function(n1, n2, m1, psi, np.arange(mode + 1, uu + 1))
+        r = _r_function(n1, n2, m1, psi, np.arange(mode + 1, uu + 1))
         pi[(mode + 1 - ll) : (uu - ll + 1)] = np.cumprod(r)
 
     if mode > ll:
-        r = 1 / r_function(
+        r = 1 / _r_function(
             n1,
             n2,
             m1,
@@ -86,9 +84,9 @@ def non_central_hypergeometric_sample(n1, n2, m1, psi):
     pi = density
 
     if mode == ll:
-        return sample_low_to_high(ll, ran, pi, -ll, uu)
+        return _sample_low_to_high(ll, ran, pi, -ll, uu)
     if mode == uu:
-        return sample_high_to_low(uu, ran, pi, -ll, ll)
+        return _sample_high_to_low(uu, ran, pi, -ll, ll)
     if ran < pi[mode - ll]:
         return mode
     ran = ran - pi[mode - ll]
@@ -101,7 +99,7 @@ def non_central_hypergeometric_sample(n1, n2, m1, psi):
                 return upper
             ran = ran - pi[upper - ll]
             if upper == uu:
-                samp = sample_high_to_low(lower, ran, pi, -ll, ll)
+                samp = _sample_high_to_low(lower, ran, pi, -ll, ll)
                 return samp
             upper = upper + 1
 
@@ -110,6 +108,6 @@ def non_central_hypergeometric_sample(n1, n2, m1, psi):
                 return lower
             ran = ran - pi[lower - ll]
             if lower == ll:
-                samp = sample_low_to_high(upper, ran, pi, -ll, uu)
+                samp = _sample_low_to_high(upper, ran, pi, -ll, uu)
                 return samp
             lower = lower - 1

--- a/pyei/goodmans_er.py
+++ b/pyei/goodmans_er.py
@@ -1,28 +1,21 @@
-"""
-Goodman's ecological regression
-"""
+"""Goodman's ecological regression"""
 
-from matplotlib import pyplot as plt
 import numpy as np
 import pymc as pm
-from sklearn.linear_model import LinearRegression
 import seaborn as sns
 import seaborn.algorithms as sns_algo
 import seaborn.utils as sns_utils
+from matplotlib import pyplot as plt
+from sklearn.linear_model import LinearRegression
 
-from .two_by_two import TwoByTwoEIBaseBayes
-
-__all__ = ["GoodmansER", "GoodmansERBayes"]
+from pyei.two_by_two import TwoByTwoEIBaseBayes
 
 
 class GoodmansER:
-    """
-    Fitting and plotting for Goodman's ER (with options for pop weighting)
-    """
+    """Fitting and plotting for Goodman's ER (with options for pop weighting)"""
 
     def __init__(self, is_weighted_regression=False):
-        """
-        Parameters
+        """Parameters
         ----------
         is_weighted_regression: bool, optional
             Default is False. If true, weight precincts by population when
@@ -135,16 +128,21 @@ class GoodmansER:
             scatter_kws.setdefault("linewidths", 0)
             scatter_kws.setdefault("alpha", 0.8)
             sns.lineplot(
-                x=[0, 1], y=[self.intercept_, self.intercept_ + self.slope_], ax=ax, **line_kws
+                x=[0, 1],
+                y=[self.intercept_, self.intercept_ + self.slope_],
+                ax=ax,
+                **line_kws,
             )
             sns.scatterplot(
-                x=self.demographic_group_fraction, y=self.vote_fraction, ax=ax, **scatter_kws
+                x=self.demographic_group_fraction,
+                y=self.vote_fraction,
+                ax=ax,
+                **scatter_kws,
             )
             xgrid = np.linspace(0, 1, 101)
 
             def fit_fast(xgrid, x, y, w):
-                """
-                Modifying this function from sns to accomodate weighted regression
+                """Modifying this function from sns to accomodate weighted regression
                 in CI computation
                 """
 
@@ -159,7 +157,13 @@ class GoodmansER:
                 grid = np.c_[np.ones(len(xgrid)), xgrid]  # append ones for intercept
                 yhat = grid.dot(weighted_reg_func(x_with_ones, y, w))
                 beta_boots = sns_algo.bootstrap(
-                    x_with_ones, y, w, func=weighted_reg_func, n_boot=1000, units=None, seed=None
+                    x_with_ones,
+                    y,
+                    w,
+                    func=weighted_reg_func,
+                    n_boot=1000,
+                    units=None,
+                    seed=None,
                 ).T
                 yhat_boots = grid.dot(beta_boots).T
                 return yhat, yhat_boots
@@ -198,8 +202,7 @@ class GoodmansERBayes(TwoByTwoEIBaseBayes):
         weighted_by_pop=False,
         **additional_model_params,
     ):
-        """
-        Optional arguments:
+        """Optional arguments:
         model_name: str
             Default is "goodman_er_bayes"
         weighted_by_pop: bool
@@ -257,10 +260,10 @@ class GoodmansERBayes(TwoByTwoEIBaseBayes):
         self.votes_fraction = votes_fraction
 
         if self.weighted_by_pop:
-            model_function = goodmans_er_bayes_pop_weighted_model
+            model_function = _goodmans_er_bayes_pop_weighted_model
             self.additional_model_params["precinct_pops"] = precinct_pops
         else:
-            model_function = goodmans_er_bayes_model
+            model_function = _goodmans_er_bayes_model
         self.sim_model = model_function(
             group_fraction, votes_fraction, **self.additional_model_params
         )
@@ -277,11 +280,15 @@ class GoodmansERBayes(TwoByTwoEIBaseBayes):
         """Sets sampled_voting_prefs"""
         # obtain samples of the districtwide proportion of each demog. group voting for candidate
         self.sampled_voting_prefs[0] = (
-            self.sim_trace["posterior"]["b_1"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_1"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
         )
         # sampled voted prefs across precincts
         self.sampled_voting_prefs[1] = (
-            self.sim_trace["posterior"]["b_2"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_2"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
         )
         # sampled voted prefs across precincts
 
@@ -353,14 +360,16 @@ class GoodmansERBayes(TwoByTwoEIBaseBayes):
             **scatter_kws,
         )
         ax.plot(x_vals, means, **line_kws)
-        ax.fill_between(x_vals, lower_bounds, upper_bounds, alpha=0.2, color=line_kws["color"])
+        ax.fill_between(
+            x_vals, lower_bounds, upper_bounds, alpha=0.2, color=line_kws["color"]
+        )
         ax.grid()
         ax.set_xlim((0, 1))
         ax.set_ylim((0, 1))
         return ax
 
 
-def goodmans_er_bayes_model(group_fraction, votes_fraction, sigma=1):
+def _goodmans_er_bayes_model(group_fraction, votes_fraction, sigma=1):
     """Ecological regression with uniform priors over voting prefs b_1, b_2,
     constraining them to be between zero and 1
 
@@ -372,11 +381,10 @@ def goodmans_er_bayes_model(group_fraction, votes_fraction, sigma=1):
     votes_fraction  :   Length p vector giving the fraction of each precinct_pop
                             that votes for the candidate of interest (T)
 
-    Returns
+    Returns:
     -------
     bayes_er_model: a pymc3 model
     """
-
     with pm.Model() as bayes_er_model:
         b_1 = pm.Uniform("b_1")
         b_2 = pm.Uniform("b_2")
@@ -393,7 +401,9 @@ def goodmans_er_bayes_model(group_fraction, votes_fraction, sigma=1):
     return bayes_er_model
 
 
-def goodmans_er_bayes_pop_weighted_model(group_fraction, votes_fraction, precinct_pops, sigma=1):
+def _goodmans_er_bayes_pop_weighted_model(
+    group_fraction, votes_fraction, precinct_pops, sigma=1
+):
     """Ecological regression with variance of modeled vote fraction inversely proportional to
     precinct population.
 
@@ -409,11 +419,10 @@ def goodmans_er_bayes_pop_weighted_model(group_fraction, votes_fraction, precinc
     precinct_pops   :   Length-p vector giving size of each precinct population
                             of interest (e.g. voting population) (N)
 
-    Returns
+    Returns:
     -------
     bayes_er_model: a pymc3 model
     """
-
     mean_precinct_pop = precinct_pops.mean()
     with pm.Model() as bayes_er_model:
         b_1 = pm.Uniform("b_1")

--- a/pyei/greiner_quinn_gibbs_sampling.py
+++ b/pyei/greiner_quinn_gibbs_sampling.py
@@ -1,5 +1,4 @@
-"""
-Functionality for Gibbs sampler to generate posterior samples
+"""Functionality for Gibbs sampler to generate posterior samples
 from model from James Greiner, D. and Quinn, K.M., 2009.
 R× C ecological inference: bounds, correlations, flexibility
 and transparency of assumptions. Journal of the Royal Statistical
@@ -7,14 +6,14 @@ Society: Series A (Statistics in Society), 172(1), pp.67-81.
 """
 
 import random
-import scipy.stats as st
-import numpy as np
-import arviz as az
-from tqdm import tqdm
-from numba import njit, prange
-from pyei.distribution_utils import non_central_hypergeometric_sample
 
-__all__ = ["pyei_greiner_quinn_sample", "greiner_quinn_gibbs_sample"]
+import arviz as az
+import numpy as np
+import scipy.stats as st
+from numba import njit, prange
+from tqdm import tqdm
+
+from pyei.distribution_utils import non_central_hypergeometric_sample
 
 
 def pyei_greiner_quinn_sample(  # pylint: disable=too-many-locals
@@ -29,8 +28,7 @@ def pyei_greiner_quinn_sample(  # pylint: disable=too-many-locals
     mu_0=None,
     gamma=0.1,
 ):
-    """
-    Converts pyei inputs to counts for gq, sets default hyperparams,
+    """Converts pyei inputs to counts for gq, sets default hyperparams,
     runs sampler, returns samples as an arviz InferenceData object
 
     Parameters:
@@ -113,7 +111,9 @@ def pyei_greiner_quinn_sample(  # pylint: disable=too-many-locals
             1 / 10 * np.identity(num_groups * (num_candidates - 1))
         )  # relates to prior precision
     if k_0_inv is None:
-        k_0_inv = 1 / (0.5) * np.identity(num_groups * (num_candidates - 1))  # same size as Sigma
+        k_0_inv = (
+            1 / (0.5) * np.identity(num_groups * (num_candidates - 1))
+        )  # same size as Sigma
     if mu_0 is None:
         votes_all_precincts = vote_counts.sum(axis=0)
         log_ratio_support = np.log(
@@ -134,18 +134,29 @@ def pyei_greiner_quinn_sample(  # pylint: disable=too-many-locals
     )
     # convert to InferenceData object
     for var_name in samples.keys():  # pylint: disable=consider-iterating-dictionary
-        samples[var_name] = np.expand_dims(samples[var_name], 0)  # add an axis for chain
-    samples["b"] = samples.pop("theta")  # changing variable name for vote prefernces to match pyei
+        samples[var_name] = np.expand_dims(
+            samples[var_name], 0
+        )  # add an axis for chain
+    samples["b"] = samples.pop(
+        "theta"
+    )  # changing variable name for vote prefernces to match pyei
     idata = az.from_dict(samples)
 
     return idata
 
 
 def greiner_quinn_gibbs_sample(  # pylint: disable=too-many-locals
-    group_counts, vote_counts, num_samples, nu_0, psi_0, k_0_inv, mu_0, gamma=0.1, burnin=0
+    group_counts,
+    vote_counts,
+    num_samples,
+    nu_0,
+    psi_0,
+    k_0_inv,
+    mu_0,
+    gamma=0.1,
+    burnin=0,
 ):
-    """
-    group_counts: ndarray
+    """group_counts: ndarray
         num_precincts x r gives number of people for each of r groups
         in num_precincts precincts
     vote_counts: ndarray
@@ -197,8 +208,8 @@ def greiner_quinn_gibbs_sample(  # pylint: disable=too-many-locals
     Sigma_samp = st.invwishart.rvs(df=nu_0, scale=psi_0)
     omega_samp = np.zeros((num_precincts, num_groups * (num_candidates - 1)))
     print(num_groups, num_candidates)
-    theta_samp = omega_to_theta(omega_samp, num_groups, num_candidates)
-    internal_cell_counts_samp = get_initial_internal_count_sample(
+    theta_samp = _omega_to_theta(omega_samp, num_groups, num_candidates)
+    internal_cell_counts_samp = _get_initial_internal_count_sample(
         group_counts, vote_counts, precinct_pops
     )
 
@@ -206,34 +217,49 @@ def greiner_quinn_gibbs_sample(  # pylint: disable=too-many-locals
     internal_cell_counts_samples = np.empty(
         (num_samples - burnin, num_precincts, num_groups, num_candidates)
     )
-    theta_samples = np.empty((num_samples - burnin, num_precincts, num_groups, num_candidates))
+    theta_samples = np.empty(
+        (num_samples - burnin, num_precincts, num_groups, num_candidates)
+    )
     mu_samples = np.empty((num_samples - burnin, num_groups * (num_candidates - 1)))
     sigma_samples = np.empty(
-        (num_samples - burnin, num_groups * (num_candidates - 1), num_groups * (num_candidates - 1))
+        (
+            num_samples - burnin,
+            num_groups * (num_candidates - 1),
+            num_groups * (num_candidates - 1),
+        )
     )
 
     for i in tqdm(range(num_samples)):
         # (a) sample internal cell counts
-        internal_cell_counts_samp = sample_internal_cell_counts(
+        internal_cell_counts_samp = _sample_internal_cell_counts(
             theta_samp, internal_cell_counts_samp
         )
 
         # (b) sample theta using Metropolis-Hastings
-        theta_samp = sample_theta(
-            internal_cell_counts_samp, theta_samp, omega_samp, mu_samp, Sigma_samp, gamma
+        theta_samp = _sample_theta(
+            internal_cell_counts_samp,
+            theta_samp,
+            omega_samp,
+            mu_samp,
+            Sigma_samp,
+            gamma,
         )
 
-        omega_samp = theta_to_omega(theta_samp)
+        omega_samp = _theta_to_omega(theta_samp)
         # TODO: IS THE NEXT LINE UNNECESSARY?
-        omega_samp = omega_samp.reshape((num_precincts, num_groups * (num_candidates - 1)))
+        omega_samp = omega_samp.reshape(
+            (num_precincts, num_groups * (num_candidates - 1))
+        )
 
         # (c) sample mu and sigma given omega (or, equivalently, given theta)
-        mu_samp = sample_mu(omega_samp, Sigma_samp, k_0_inv, mu_0, num_precincts)
-        Sigma_samp = sample_Sigma(omega_samp, mu_samp, nu_0, psi_0)
+        mu_samp = _sample_mu(omega_samp, Sigma_samp, k_0_inv, mu_0, num_precincts)
+        Sigma_samp = _sample_Sigma(omega_samp, mu_samp, nu_0, psi_0)
 
         # save samples after burn-in
         if i >= burnin:
-            internal_cell_counts_samples[i - burnin, :, :, :] = internal_cell_counts_samp
+            internal_cell_counts_samples[i - burnin, :, :, :] = (
+                internal_cell_counts_samp
+            )
             theta_samples[i - burnin, :, :, :] = theta_samp
             mu_samples[i - burnin, :] = mu_samp
             sigma_samples[i - burnin, :, :] = Sigma_samp
@@ -246,9 +272,8 @@ def greiner_quinn_gibbs_sample(  # pylint: disable=too-many-locals
     }
 
 
-def sample_Sigma(omega, mu, nu_0, psi_0):
-    """
-    Parameters:
+def _sample_Sigma(omega, mu, nu_0, psi_0):
+    """Parameters:
     -----------
     omega: ndarray
         num_precints x (r * (c - 1))
@@ -281,9 +306,8 @@ def sample_Sigma(omega, mu, nu_0, psi_0):
     return Sigma
 
 
-def sample_mu(omega, Sigma, k_0_inv, mu_0, num_precincts):
-    """
-    omega: num_precints x (r * (c - 1))
+def _sample_mu(omega, Sigma, k_0_inv, mu_0, num_precincts):
+    """omega: num_precints x (r * (c - 1))
     Sigma: ndarray
         square matrix r * (c - 1) x r * (c - 1), the covariance of omega
     k_0_inv is hyperparameter - square matrix r * (c - 1) x r * (c - 1)
@@ -303,7 +327,6 @@ def sample_mu(omega, Sigma, k_0_inv, mu_0, num_precincts):
     Returns:
     mu: a vector of length r * (c-1)
     """
-
     Sigma_inv = np.linalg.inv(Sigma)
     mean_omega = np.mean(omega, axis=0)
     mu_n = (np.linalg.inv(k_0_inv + num_precincts * Sigma_inv)) @ (
@@ -315,9 +338,10 @@ def sample_mu(omega, Sigma, k_0_inv, mu_0, num_precincts):
     return mu
 
 
-def proposal_dist_generate_sample(mu_samp, Sigma_samp, gamma, num_precincts, deg_freedom=4):
-    """
-    Grainer and Quinn use a t_4(mu_t, gamma * Sigma) proposal dist with gamma
+def _proposal_dist_generate_sample(
+    mu_samp, Sigma_samp, gamma, num_precincts, deg_freedom=4
+):
+    """Grainer and Quinn use a t_4(mu_t, gamma * Sigma) proposal dist with gamma
     set during inital runs - this generates an omega sample, which they transform
     back to theta space
 
@@ -331,8 +355,10 @@ def proposal_dist_generate_sample(mu_samp, Sigma_samp, gamma, num_precincts, deg
     return omega_proposed
 
 
-def log_unnormalized_pdf(theta, omega, internal_cell_counts_samp, mu_samp, Sigma_samp, tol=0.01):
-    """pdf proportional t to the product of lines (4)-(6) and (10) and (11) in G&Q
+def _log_unnormalized_pdf(
+    theta, omega, internal_cell_counts_samp, mu_samp, Sigma_samp, tol=0.01
+):
+    """Pdf proportional t to the product of lines (4)-(6) and (10) and (11) in G&Q
     0 if thetas don't sum to 1 across rows
 
     Sigma_samp: ndarray
@@ -342,9 +368,10 @@ def log_unnormalized_pdf(theta, omega, internal_cell_counts_samp, mu_samp, Sigma
     theta: ndarray
         num_precints x r x c
     """
-
     # Lines (10) - (11) are this check
-    if not np.all(abs(theta.sum(axis=2) - 1) < tol):  # CHECK IF THETAS SUM TO 1 across rows
+    if not np.all(
+        abs(theta.sum(axis=2) - 1) < tol
+    ):  # CHECK IF THETAS SUM TO 1 across rows
         return -np.inf  # if not, prob is zero, so log_prob is -inf
 
     else:
@@ -357,9 +384,8 @@ def log_unnormalized_pdf(theta, omega, internal_cell_counts_samp, mu_samp, Sigma
         return (line_4_and_6 + line_5).sum()  # sum over precincts
 
 
-def theta_to_omega(theta):
-    """
-    Parameters:
+def _theta_to_omega(theta):
+    """Parameters:
     -----------
     theta: ndarray
         num_precints x r x c
@@ -372,9 +398,10 @@ def theta_to_omega(theta):
     return np.log(theta[:, :, :-1]) - np.log(theta[:, :, [-1]])
 
 
-def sample_theta(internal_cell_counts_samp, theta_prev, omega_prev, mu_samp, Sigma_samp, gamma):
-    """
-    Use a Metropolis-Hastings step to sample theta
+def _sample_theta(
+    internal_cell_counts_samp, theta_prev, omega_prev, mu_samp, Sigma_samp, gamma
+):
+    """Use a Metropolis-Hastings step to sample theta
 
     internal_cell_counts_samp: ndarray
     theta_prev: ndarray
@@ -389,16 +416,16 @@ def sample_theta(internal_cell_counts_samp, theta_prev, omega_prev, mu_samp, Sig
     # MH
     num_precincts, r, c = internal_cell_counts_samp.shape
 
-    omega_proposed = proposal_dist_generate_sample(
+    omega_proposed = _proposal_dist_generate_sample(
         mu_samp, Sigma_samp, gamma, num_precincts, deg_freedom=4
     )
 
-    theta_proposed = omega_to_theta(omega_proposed, r, c)
+    theta_proposed = _omega_to_theta(omega_proposed, r, c)
 
-    log_unnormalized_pdf_proposed = log_unnormalized_pdf(
+    log_unnormalized_pdf_proposed = _log_unnormalized_pdf(
         theta_proposed, omega_proposed, internal_cell_counts_samp, mu_samp, Sigma_samp
     )
-    log_unnormalized_pdf_prev = log_unnormalized_pdf(
+    log_unnormalized_pdf_prev = _log_unnormalized_pdf(
         theta_prev, omega_prev, internal_cell_counts_samp, mu_samp, Sigma_samp
     )
 
@@ -414,9 +441,8 @@ def sample_theta(internal_cell_counts_samp, theta_prev, omega_prev, mu_samp, Sig
         return theta_prev
 
 
-def omega_to_theta(omega, r, c):
-    """
-    theta: num_precints x r x c
+def _omega_to_theta(omega, r, c):
+    """theta: num_precints x r x c
     omega: num_precincts x (r * (c-1))
 
     Note:
@@ -432,9 +458,8 @@ def omega_to_theta(omega, r, c):
 
 
 @njit(parallel=True)
-def sample_internal_cell_counts(theta_samp, prev_internal_counts_samp):
-    """
-    group_counts: num_precincts x r
+def _sample_internal_cell_counts(theta_samp, prev_internal_counts_samp):
+    """group_counts: num_precincts x r
     vote_counts: num_precincts x c
     theta: num_precints x r x c
     prev_internal_counts_samp: num_precincts x r x c
@@ -478,9 +503,8 @@ def sample_internal_cell_counts(theta_samp, prev_internal_counts_samp):
 
 
 @njit(parallel=True, nopython=False)
-def get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
-    """
-    Sets an initial value of internal counts that is compatible with the
+def _get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
+    """Sets an initial value of internal counts that is compatible with the
     observed vote and group counts
 
     Parameters:
@@ -515,7 +539,9 @@ def get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
     """
     num_precincts, num_groups = group_counts.shape
     _, num_candidates = vote_counts.shape
-    internal_counts_samp = np.empty((num_precincts, num_groups, num_candidates), dtype=np.int16)
+    internal_counts_samp = np.empty(
+        (num_precincts, num_groups, num_candidates), dtype=np.int16
+    )
 
     group_counts_remaining = group_counts.copy()
     vote_counts_remaining = vote_counts.copy()
@@ -536,7 +562,9 @@ def get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops):
                 group_counts_remaining[i, r] = group_counts_remaining[i, r] - samp
                 vote_counts_remaining[i, c] = vote_counts_remaining[i, c] - samp
                 internal_counts_samp[i, r, c] = samp
-            internal_counts_samp[i, r, num_candidates - 1] = group_counts_remaining[i, r]
+            internal_counts_samp[i, r, num_candidates - 1] = group_counts_remaining[
+                i, r
+            ]
             vote_counts_remaining[i, num_candidates - 1] = (
                 vote_counts_remaining[i, num_candidates - 1]
                 - internal_counts_samp[i, r, num_candidates - 1]

--- a/pyei/plot_utils.py
+++ b/pyei/plot_utils.py
@@ -1,30 +1,16 @@
-"""
-Plotting functions for visualizing ei outputs
-
-"""
+"""Plotting functions for visualizing ei outputs"""
 
 import warnings
-import seaborn as sns
+
+import matplotlib.patches as mpatches
+import numpy as np
 import pandas as pd
+import scipy.stats as st
+import seaborn as sns
 from matplotlib import pyplot as plt
 from matplotlib import ticker as mticker
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Rectangle
-import matplotlib.patches as mpatches
-import numpy as np
-import scipy.stats as st
-
-__all__ = [
-    "plot_boxplots",
-    "plot_conf_or_credible_interval",
-    "plot_intervals_all_precincts",
-    "plot_kdes",
-    "plot_polarization_kde",
-    "plot_precinct_scatterplot",
-    "plot_precincts",
-    "plot_summary",
-    "tomography_plot",
-]
 
 PALETTE = "Dark2"  # set library-wide color palette
 FONTSIZE = 20
@@ -34,9 +20,8 @@ FIGSIZE = (10, 5)
 colors = sns.color_palette(PALETTE)
 
 
-def size_ticks(ax, axis="x"):
-    """
-    Helper function to size the x- or ytick (numbers) of a matplotlib Axis
+def _size_ticks(ax, axis="x"):
+    """Helper function to size the x- or ytick (numbers) of a matplotlib Axis
 
     Parameters
     ----------
@@ -58,9 +43,8 @@ def size_ticks(ax, axis="x"):
         raise ValueError("You need to specify an 'x' or 'y' axis!")
 
 
-def size_yticklabels(ax):
-    """
-    Helper function to size the ytick labels of a matplotlib Axis
+def _size_yticklabels(ax):
+    """Helper function to size the ytick labels of a matplotlib Axis
 
     Parameters
     ----------
@@ -69,7 +53,7 @@ def size_yticklabels(ax):
     ax.set_yticklabels(ax.get_yticklabels(), size=TICKSIZE)
 
 
-def plot_single_ridgeplot(
+def _plot_single_ridgeplot(
     ax,
     group_prefs,
     colors,  # pylint: disable=redefined-outer-name
@@ -129,7 +113,7 @@ def plot_single_ridgeplot(
         )
 
 
-def plot_single_histogram(
+def _plot_single_histogram(
     ax,
     group_prefs,
     colors,  # pylint: disable=redefined-outer-name
@@ -154,7 +138,6 @@ def plot_single_histogram(
     trans
         The y-translation for this plot
     """
-
     bins = np.linspace(0, 1.0, num=20)
     for i, group_pref in enumerate(group_prefs):
         weights, bins = np.histogram(group_pref, bins=bins)
@@ -207,7 +190,7 @@ def plot_precincts(
     ax : Matplotlib axis object or None, optional
         Default=None
 
-    Returns
+    Returns:
     -------
     ax: Matplotlib axis object
     """
@@ -237,9 +220,9 @@ def plot_precincts(
         ax.plot([0], [idx])
         trans = ax.convert_yunits(idx)
         if plot_as_histograms:
-            plot_single_histogram(ax, group_prefs, colors, alpha, 4 * (N - idx), trans)
+            _plot_single_histogram(ax, group_prefs, colors, alpha, 4 * (N - idx), trans)
         else:
-            plot_single_ridgeplot(ax, group_prefs, colors, alpha, 4 * (N - idx), trans)
+            _plot_single_ridgeplot(ax, group_prefs, colors, alpha, 4 * (N - idx), trans)
     for i in range(legend_space):
         # add `legend_space` number of lines to the top of the plot for legend
         ax.plot([0], [N + i])
@@ -254,7 +237,9 @@ def plot_precincts(
 
     # replace y-axis ticks with precinct labels
     ax.set_yticks(np.arange(len(precinct_labels)))
-    ax.yaxis.set_major_formatter(mticker.FuncFormatter(replace_ticks_with_precinct_labels))
+    ax.yaxis.set_major_formatter(
+        mticker.FuncFormatter(replace_ticks_with_precinct_labels)
+    )
     ax.set_title("Precinct level estimates of voting preferences", fontsize=TITLESIZE)
     ax.set_xlabel(f"Percent vote for {candidate}", fontsize=FONTSIZE)
     ax.set_ylabel("Precinct", fontsize=FONTSIZE)
@@ -265,15 +250,14 @@ def plot_precincts(
     ]
     ax.legend(handles=proxy_handles, prop={"size": 14}, loc="upper center")
     ax.set_ylim(-1, ax.get_ylim()[1])
-    size_ticks(ax, "x")
+    _size_ticks(ax, "x")
     return ax
 
 
 def plot_boxplots(
     sampled_voting_prefs, group_names, candidate_names, plot_by="candidate", axes=None
 ):
-    """
-    Horizontal boxplots for r x c sets of samples between 0 and 1
+    """Horizontal boxplots for r x c sets of samples between 0 and 1
 
     Parameters
     ----------
@@ -301,17 +285,16 @@ def plot_boxplots(
         If not None and plot_by is 'candidate', should have length c (number of candidates).
         If plot_by is 'group', should have length r (number of groups)
 
-    Returns
+    Returns:
     -------
     ax : Matplotlib axis object
         Has c subplots, each showing the sampled voting preference of each of r groups.
 
-    Notes
+    Notes:
     -----
     If passing existing axes within a subplot, consider using, e.g.,
     plt.subplots_adjust(hspace=0.75) to make control spacing
     """
-
     _, num_groups, num_candidates = sampled_voting_prefs.shape
     if plot_by == "candidate":
         num_plots = num_candidates
@@ -332,22 +315,29 @@ def plot_boxplots(
         if axes is None:
             _, axes = plt.subplots(num_groups, figsize=FIGSIZE)
     else:
-        raise ValueError("plot_by must be 'group' or 'candidate' (default: 'candidate')")
+        raise ValueError(
+            "plot_by must be 'group' or 'candidate' (default: 'candidate')"
+        )
     plt.gcf().subplots_adjust(hspace=1)
 
     for plot_idx in range(num_plots):
         samples_df = pd.DataFrame(
-            {legend[i]: sampled_voting_prefs[:, i, plot_idx] for i in range(num_boxes_per_plot)}
+            {
+                legend[i]: sampled_voting_prefs[:, i, plot_idx]
+                for i in range(num_boxes_per_plot)
+            }
         )
         if num_plots > 1:
             ax = axes[plot_idx]
         else:
             ax = axes
-        sns.boxplot(data=samples_df, orient="h", whis=[2.5, 97.5], ax=ax, palette=colors)
+        sns.boxplot(
+            data=samples_df, orient="h", whis=[2.5, 97.5], ax=ax, palette=colors
+        )
         ax.set_title(f"Support {support} {titles[plot_idx]}", fontsize=TITLESIZE)
         ax.tick_params(axis="y", left=False)  # remove y axis ticks
-        size_ticks(ax, "x")
-        size_yticklabels(ax)
+        _size_ticks(ax, "x")
+        _size_yticklabels(ax)
 
     return ax
 
@@ -376,7 +366,7 @@ def plot_summary(
         Default=None
         Length 2: (ax_box, ax_hist)
 
-    Returns
+    Returns:
     -------
     ax_box : Matplotlib axis object
     ax_hist : Matplotlib axis object
@@ -390,7 +380,7 @@ def plot_summary(
         )
     else:
         ax_hist, ax_box = axes
-    size_ticks(ax_box, "x")
+    _size_ticks(ax_box, "x")
     ax_box.set_title("")
     ax_box.set_xlabel(f"Support for {candidate_name}", fontsize=FONTSIZE)
     sns.despine(ax=ax_hist)
@@ -418,15 +408,18 @@ def plot_summary(
     ax_box.tick_params(axis="y", left=False)  # remove y axis ticks
 
     # plot distribution
-    plot_kdes(sampled_voting_prefs, [group1_name, group2_name], [candidate_name], axes=ax_hist)
+    plot_kdes(
+        sampled_voting_prefs, [group1_name, group2_name], [candidate_name], axes=ax_hist
+    )
     ax_hist.set_title("EI Summary", fontsize=TITLESIZE)
     plt.subplots_adjust(hspace=0.005)
     return (ax_box, ax_hist)
 
 
-def plot_precinct_scatterplot(ei_runs, run_names, candidate, demographic_group="all", ax=None):
-    """
-    Given two RxC EI runs, plot precinct-by-precinct comparison of preferences
+def plot_precinct_scatterplot(
+    ei_runs, run_names, candidate, demographic_group="all", ax=None
+):
+    """Given two RxC EI runs, plot precinct-by-precinct comparison of preferences
     for a given candidate from a given demographic group.
 
     Parameters
@@ -444,7 +437,7 @@ def plot_precinct_scatterplot(ei_runs, run_names, candidate, demographic_group="
         Must be a demographic group common to both EI runs, or "all",
         which plots and labels each demographic group onto the same axes.
 
-    Returns
+    Returns:
     -------
     ax: Matplotlib axis object
     """
@@ -476,7 +469,9 @@ def plot_precinct_scatterplot(ei_runs, run_names, candidate, demographic_group="
         demographic_group_names2 = ei_runs[1].demographic_group_names
         candidate_names2 = ei_runs[1].candidate_names
 
-    common_groups = [g for g in demographic_group_names1 if g in demographic_group_names2]
+    common_groups = [
+        g for g in demographic_group_names1 if g in demographic_group_names2
+    ]
 
     group_dict = {}
     for group in common_groups:
@@ -510,15 +505,16 @@ def plot_precinct_scatterplot(ei_runs, run_names, candidate, demographic_group="
     ax.set_xlabel(f"Support for {candidate} (from {run_names[0]})", fontsize=FONTSIZE)
     ax.set_ylabel(f"Support for {candidate} (from {run_names[1]})", fontsize=FONTSIZE)
     ax.legend()
-    size_ticks(ax, "x")
-    size_ticks(ax, "y")
+    _size_ticks(ax, "x")
+    _size_ticks(ax, "y")
 
     return ax
 
 
-def plot_margin_kde(group, candidates, samples, thresholds, percentile, show_threshold, ax):
-    """
-    Plots a kde for the margin between two candidates among a given demographic group
+def plot_margin_kde(
+    group, candidates, samples, thresholds, percentile, show_threshold, ax
+):
+    """Plots a kde for the margin between two candidates among a given demographic group
 
     Parameters:
     -----------
@@ -533,7 +529,7 @@ def plot_margin_kde(group, candidates, samples, thresholds, percentile, show_thr
     show_threshold: bool
         if true, add vertical lines at the threshold on the plot
 
-    Returns
+    Returns:
     -------
     ax: Matplotlib axis object
     """
@@ -568,8 +564,12 @@ def plot_margin_kde(group, candidates, samples, thresholds, percentile, show_thr
             fontsize=FONTSIZE,
         )
 
-    ax.set_title(f"{candidates[0]} - {candidates[1]} margin among {group}", fontsize=TITLESIZE)
-    ax.set_xlabel(f"{group} support for {candidates[0]} - {candidates[1]}", fontsize=FONTSIZE)
+    ax.set_title(
+        f"{candidates[0]} - {candidates[1]} margin among {group}", fontsize=TITLESIZE
+    )
+    ax.set_xlabel(
+        f"{group} support for {candidates[0]} - {candidates[1]}", fontsize=FONTSIZE
+    )
     ax.set_xlim((-1, 1))
     xticks = ax.get_xticks()
     ax.set_xticks(xticks)
@@ -586,8 +586,7 @@ def plot_polarization_kde(
     ax=None,
     color="steelblue",
 ):
-    """
-    Plots a kde for the differences in voting preferences between two groups
+    """Plots a kde for the differences in voting preferences between two groups
 
     Parameters:
     -----------
@@ -607,11 +606,10 @@ def plot_polarization_kde(
     color: str
         specifies a color for matplotlib to be used in the histogram/kde
 
-    Returns
+    Returns:
     -------
     ax: Matplotlib axis object
     """
-
     if ax is None:
         _, ax = plt.subplots(figsize=FIGSIZE)
 
@@ -645,7 +643,9 @@ def plot_polarization_kde(
         )
 
     ax.set_title(f"Polarization KDE for {candidate_name}", fontsize=TITLESIZE)
-    ax.set_xlabel(f"({groups[0]} - {groups[1]}) support for {candidate_name}", fontsize=FONTSIZE)
+    ax.set_xlabel(
+        f"({groups[0]} - {groups[1]}) support for {candidate_name}", fontsize=FONTSIZE
+    )
     ax.set_xlim((-1, 1))
     xticks = ax.get_xticks()
     ax.set_xticks(xticks)
@@ -654,9 +654,10 @@ def plot_polarization_kde(
     return ax
 
 
-def plot_kdes(sampled_voting_prefs, group_names, candidate_names, plot_by="candidate", axes=None):
-    """
-    Plot a kernel density plot for prefs of voting groups for each candidate
+def plot_kdes(
+    sampled_voting_prefs, group_names, candidate_names, plot_by="candidate", axes=None
+):
+    """Plot a kernel density plot for prefs of voting groups for each candidate
 
     Parameters
     ----------
@@ -680,11 +681,10 @@ def plot_kdes(sampled_voting_prefs, group_names, candidate_names, plot_by="candi
         If not None and plot_by is 'candidate', should have length c (number of candidates).
         If plot_by is 'group', should have length r (number of groups)
 
-    Returns
+    Returns:
     -------
     ax : Matplotlib axis object
     """
-
     _, num_groups, num_candidates = sampled_voting_prefs.shape
     if plot_by == "candidate":
         num_plots = num_candidates
@@ -706,7 +706,9 @@ def plot_kdes(sampled_voting_prefs, group_names, candidate_names, plot_by="candi
             _, axes = plt.subplots(num_groups, figsize=FIGSIZE, sharex=True)
             plt.subplots_adjust(hspace=0.5)
     else:
-        raise ValueError("plot_by must be 'group' or 'candidate' (default: 'candidate')")
+        raise ValueError(
+            "plot_by must be 'group' or 'candidate' (default: 'candidate')"
+        )
 
     middle_plot = int(np.floor(num_plots / 2))
     for plot_idx in range(num_plots):
@@ -718,7 +720,7 @@ def plot_kdes(sampled_voting_prefs, group_names, candidate_names, plot_by="candi
             axes.set_ylabel("Probability Density", fontsize=FONTSIZE)
         ax.set_title(f"Support {support} " + titles[plot_idx], fontsize=TITLESIZE)
         ax.set_xlim((0, 1))
-        size_ticks(ax, "x")
+        _size_ticks(ax, "x")
 
         for kde_idx in range(num_kdes_per_plot):
             sns.histplot(
@@ -734,15 +736,18 @@ def plot_kdes(sampled_voting_prefs, group_names, candidate_names, plot_by="candi
             ax.set_ylabel("")
 
     if num_plots > 1:
-        axes[middle_plot].legend(bbox_to_anchor=(1, 1), loc="upper left", prop={"size": 12})
+        axes[middle_plot].legend(
+            bbox_to_anchor=(1, 1), loc="upper left", prop={"size": 12}
+        )
     else:
         ax.legend(prop={"size": 12})
     return axes
 
 
-def plot_conf_or_credible_interval(intervals, group_names, candidate_name, title, ax=None):
-    """
-    Plot confidence of credible interval for two different groups
+def plot_conf_or_credible_interval(
+    intervals, group_names, candidate_name, title, ax=None
+):
+    """Plot confidence of credible interval for two different groups
 
     Parameters
     ----------
@@ -760,11 +765,10 @@ def plot_conf_or_credible_interval(intervals, group_names, candidate_name, title
     ax : Matplotlib axis object or None, optional
         Default=None
 
-    Returns
+    Returns:
     -------
     ax : Matplotlib axis object
     """
-
     if ax is None:
         _, ax = plt.subplots(figsize=FIGSIZE)
 
@@ -790,7 +794,7 @@ def plot_conf_or_credible_interval(intervals, group_names, candidate_name, title
             alpha=0.8,
             color=colors[idx],
         )
-    size_ticks(ax, "x")
+    _size_ticks(ax, "x")
 
     return ax
 
@@ -804,8 +808,7 @@ def plot_intervals_all_precincts(
     ax=None,
     show_all_precincts=False,
 ):
-    """
-    Plot intervals&point estimates of support for candidate, sorted by point estimates for precincts
+    """Plot intervals&point estimates of support for candidate, sorted by point estimates for precincts
 
     Parameters
     ----------
@@ -826,7 +829,7 @@ def plot_intervals_all_precincts(
         (default=False). If True, show estimates&intervals for all precincts. If False,
         show only the first 50, for readibility.
 
-    Returns
+    Returns:
     -------
     ax : Matplotlib axis object
     """
@@ -919,11 +922,10 @@ def tomography_plot(
     **plot_kwargs
         Additional keyword arguments to be passed to matplotlib.Axes.plot()
 
-    Returns
+    Returns:
     -------
     ax : Matplotlib axis object
     """
-
     if ax is None:
         _, ax = plt.subplots()
 

--- a/pyei/r_by_c.py
+++ b/pyei/r_by_c.py
@@ -1,5 +1,4 @@
-"""
-Models and fitting for rxc methods
+"""Models and fitting for rxc methods
 where r and c are greater than or
 equal to 2
 
@@ -9,31 +8,28 @@ TODO: Refactor to integrate with two_by_two
 """
 
 import warnings
-import pymc as pm
+
 import numpy as np
-from .plot_utils import (
+import pymc as pm
+
+from pyei.greiner_quinn_gibbs_sampling import pyei_greiner_quinn_sample
+from pyei.plot_utils import (
     plot_boxplots,
-    plot_kdes,
     plot_intervals_all_precincts,
-    plot_polarization_kde,
+    plot_kdes,
     plot_margin_kde,
+    plot_polarization_kde,
     plot_precincts,
 )
-from .r_by_c_models import ei_multinom_dirichlet, ei_multinom_dirichlet_modified
-from .r_by_c_utils import check_dimensions_of_input
-from .greiner_quinn_gibbs_sampling import pyei_greiner_quinn_sample
-
-__all__ = ["RowByColumnEI"]
+from pyei.r_by_c_models import ei_multinom_dirichlet, ei_multinom_dirichlet_modified
+from pyei.r_by_c_utils import check_dimensions_of_input
 
 
 class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
-    """
-    Fitting and plotting for RxC models, fit via sampling
-    """
+    """Fitting and plotting for RxC models, fit via sampling"""
 
     def __init__(self, model_name, **additional_model_params):
-        """
-        Parameters:
+        """Parameters:
         -----------
         model_name: str
             The name of the model to use. Currently supported: multinomial-dirichlet,
@@ -66,7 +62,9 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         self.turnout_adjusted_sampled_voting_prefs = (
             None  # samps districtwide prefs,num_samples x r x c-1
         )
-        self.turnout_adjusted_candidate_names = None  # candidate names with no-vote column omitted
+        self.turnout_adjusted_candidate_names = (
+            None  # candidate names with no-vote column omitted
+        )
         self.turnout_adjusted_posterior_mean_voting_prefs = None
         self.turnout_adjusted_credible_interval_95_mean_voting_prefs = None
         self.turnout_samples = None
@@ -138,7 +136,9 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
 
         # give demographic groups, candidates 1-indexed numbers as names if names are not specified
         if demographic_group_names is None:
-            demographic_group_names = [str(i) for i in range(1, group_fractions.shape[0] + 1)]
+            demographic_group_names = [
+                str(i) for i in range(1, group_fractions.shape[0] + 1)
+            ]
         if candidate_names is None:
             candidate_names = [str(i) for i in range(1, votes_fractions.shape[0] + 1)]
         self.demographic_group_names = demographic_group_names
@@ -217,8 +217,7 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             self.calculate_summary()
 
     def _calculate_turnout_adjusted_samples(self, non_candidate_names):
-        """
-        For each sample, calculate the voting support of each group for each candidate
+        """For each sample, calculate the voting support of each group for each candidate
         *as a fraction of all those who voted* (instead of as a fraction of all those
         included in the precinct population. This fn is only applicable when one of the
         c voting outcomes is a no-vote or abstain column. In this case, the total number
@@ -230,21 +229,22 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             each a name of the column/ voting outcome that corresponds to not voting,
             if applicable. Each string in the list must be in candidate_names
 
-        Notes
+        Notes:
         -----
         Sets the values of:
             self.turnout_adjusted_candidate_names
             self.turnout_samples
             self.turnout_adjusted_samples
         """
-
         abstain_column_indices = []
         for non_candidate_name in non_candidate_names:
             if non_candidate_name not in self.candidate_names:
                 raise ValueError(
                     f"non_candidate_names must be in candidate_names: {self.candidate_names}"
                 )
-            abstain_column_indices.append(self.candidate_names.index(non_candidate_name))
+            abstain_column_indices.append(
+                self.candidate_names.index(non_candidate_name)
+            )
 
         non_adjusted_samples = np.transpose(
             self.sim_trace["posterior"]["b"].stack(all_draws=["chain", "draw"]).values,
@@ -267,13 +267,13 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             non_adjusted_samples, abstain_column_indices, axis=3
         )  # num_samples x num_precincts x r x c-1
 
-        self.turnout_adjusted_samples = turnout_adjusted_samples / turnout_adjusted_samples.sum(
-            axis=3, keepdims=True
+        self.turnout_adjusted_samples = (
+            turnout_adjusted_samples
+            / turnout_adjusted_samples.sum(axis=3, keepdims=True)
         )  # num_samples x num_precincts x r x c-1
 
     def calculate_turnout_adjusted_summary(self, non_candidate_names):
-        """
-        Calculates districtwide samples, means, and credible intervals
+        """Calculates districtwide samples, means, and credible intervals
 
         Parameters
         ----------
@@ -281,7 +281,7 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             each a name of the column/ voting outcome that corresponds to not voting,
             if applicable. Each string in the list must be in candidate_names
 
-        Notes
+        Notes:
         -----
         Sets turnout_adjusted_voting_prefs, turnout_adjusted_posterior_mean_voting_prefs,
             turnout_adjusted_credible_interval_95_mean_voting_prefs
@@ -289,7 +289,8 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         self._calculate_turnout_adjusted_samples(non_candidate_names)
 
         samples_converted_to_pops = (
-            np.transpose(self.turnout_adjusted_samples, axes=(3, 0, 1, 2)) * self.turnout_samples
+            np.transpose(self.turnout_adjusted_samples, axes=(3, 0, 1, 2))
+            * self.turnout_samples
         )
         # (c-1) x num_samples x num_precincts x r x
         samples_of_votes_summed_across_district = samples_converted_to_pops.sum(
@@ -318,10 +319,10 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         )
         for row in range(self.num_groups_and_num_candidates[0]):
             for col in range(self.num_groups_and_num_candidates[1] - 1):
-                self.turnout_adjusted_credible_interval_95_mean_voting_prefs[row][col][:] = (
-                    np.percentile(
-                        self.turnout_adjusted_sampled_voting_prefs[:, row, col], percentiles
-                    )
+                self.turnout_adjusted_credible_interval_95_mean_voting_prefs[row][col][
+                    :
+                ] = np.percentile(
+                    self.turnout_adjusted_sampled_voting_prefs[:, row, col], percentiles
                 )
 
     def calculate_summary(self):
@@ -356,12 +357,15 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
 
         # obtain samples of the districtwide proportion of each demog. group voting for candidate
         self.sampled_voting_prefs = np.transpose(
-            samples_of_votes_summed_across_district / demographic_group_counts.sum(axis=0),
+            samples_of_votes_summed_across_district
+            / demographic_group_counts.sum(axis=0),
             axes=(1, 2, 0),
         )  # sampled voted prefs across precincts,  num_samples x r x c
 
         # # compute point estimates
-        self.posterior_mean_voting_prefs = self.sampled_voting_prefs.mean(axis=0)  # r x c
+        self.posterior_mean_voting_prefs = self.sampled_voting_prefs.mean(
+            axis=0
+        )  # r x c
 
         # compute credible intervals
         percentiles = [2.5, 97.5]
@@ -374,13 +378,12 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         )
         for row in range(self.num_groups_and_num_candidates[0]):
             for col in range(self.num_groups_and_num_candidates[1]):
-                self.credible_interval_95_mean_voting_prefs[row][col][:] = np.percentile(
-                    self.sampled_voting_prefs[:, row, col], percentiles
+                self.credible_interval_95_mean_voting_prefs[row][col][:] = (
+                    np.percentile(self.sampled_voting_prefs[:, row, col], percentiles)
                 )
 
     def _calculate_margin(self, group, candidates, threshold=None, percentile=None):
-        """
-        Calculating the Candidate 1 - Candidate 2 margin among the given group.
+        """Calculating the Candidate 1 - Candidate 2 margin among the given group.
         Calculate the percentile given a threshold, or vice versa. Exactly one of
         {percentile, threshold} must be None.
 
@@ -416,7 +419,9 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         )
 
         if percentile is None and threshold is not None:
-            percentile = 100 * (samples > threshold).sum() / len(self.sampled_voting_prefs)
+            percentile = (
+                100 * (samples > threshold).sum() / len(self.sampled_voting_prefs)
+            )
         elif threshold is None and percentile is not None:
             threshold = np.percentile(samples, 100 - percentile)
         else:
@@ -428,9 +433,10 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             )
         return threshold, percentile, samples, group, candidates
 
-    def margin_report(self, group, candidates, threshold=None, percentile=None, verbose=True):
-        """
-        For a given threshold, return the probability that the margin between
+    def margin_report(
+        self, group, candidates, threshold=None, percentile=None, verbose=True
+    ):
+        """For a given threshold, return the probability that the margin between
         the two candidates preferences in the given demographic group is greater than
         the threshold
         OR
@@ -497,9 +503,10 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
                 )
             return percentile
 
-    def _calculate_polarization(self, groups, candidate, threshold=None, percentile=None):
-        """
-        Calculate percentile given a threshold, or vice versa.
+    def _calculate_polarization(
+        self, groups, candidate, threshold=None, percentile=None
+    ):
+        """Calculate percentile given a threshold, or vice versa.
         Exactly one of {percentile, threshold} must be None.
         Parameters:
         -----------
@@ -517,7 +524,6 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             for the polarization. At least one of threshold and percentile
             must be None
         """
-
         candidate_index = self.candidate_names.index(candidate)
         group_index_0 = self.demographic_group_names.index(groups[0])
         group_index_1 = self.demographic_group_names.index(groups[1])
@@ -528,7 +534,9 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         )
 
         if percentile is None and threshold is not None:
-            percentile = 100 * (samples > threshold).sum() / len(self.sampled_voting_prefs)
+            percentile = (
+                100 * (samples > threshold).sum() / len(self.sampled_voting_prefs)
+            )
         elif threshold is None and percentile is not None:
             threshold = np.percentile(samples, 100 - percentile)
         else:
@@ -540,9 +548,10 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             )
         return threshold, percentile, samples, groups, candidate
 
-    def polarization_report(self, groups, candidate, threshold=None, percentile=None, verbose=True):
-        """
-        For a given threshold, return the probability that the difference between
+    def polarization_report(
+        self, groups, candidate, threshold=None, percentile=None, verbose=True
+    ):
+        """For a given threshold, return the probability that the difference between
         the two demographic groups' preferences for the candidate is greater than
         the threshold
         OR
@@ -633,7 +642,9 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             self.calculate_turnout_adjusted_summary(non_candidate_names)
             candidate_names_for_summary = self.turnout_adjusted_candidate_names
             posterior_means = self.turnout_adjusted_posterior_mean_voting_prefs
-            credible_intervals = self.turnout_adjusted_credible_interval_95_mean_voting_prefs
+            credible_intervals = (
+                self.turnout_adjusted_credible_interval_95_mean_voting_prefs
+            )
         else:
             candidate_names_for_summary = self.candidate_names
             posterior_means = self.posterior_mean_voting_prefs
@@ -658,6 +669,7 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             Optional. If specified, this will give the names of column to be
             treated as no-vote columns, and the precinct-level estimates
             will be computed AMONG those who were estimated to have voted
+
         Returns:
         --------
             precinct_posterior_means: num_precincts x r x c
@@ -667,7 +679,9 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             precinct_level_samples = self.turnout_adjusted_samples
         else:
             precinct_level_samples = np.transpose(
-                self.sim_trace["posterior"]["b"].stack(all_draws=["chain", "draw"]).values,
+                self.sim_trace["posterior"]["b"]
+                .stack(all_draws=["chain", "draw"])
+                .values,
                 axes=(3, 0, 1, 2),
             )  # num_samples x num_precincts x r x c # num_samples x num_precincts x r x c
         _, _, r, c = precinct_level_samples.shape
@@ -712,13 +726,14 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
             Values are fraction of the samples in which the support of that group for that
             candidate was higher than for any other candidate
         """
-
         candidate_preference_rate_dict = {}
         if non_candidate_names is None:
             non_candidate_names = []
         non_cand_idxs = [self.candidate_names.index(n) for n in non_candidate_names]
         cand_names = [c for c in self.candidate_names if c not in non_candidate_names]
-        sampled_voting_prefs = np.delete(self.sampled_voting_prefs, non_cand_idxs, axis=2)
+        sampled_voting_prefs = np.delete(
+            self.sampled_voting_prefs, non_cand_idxs, axis=2
+        )
 
         for row in range(self.num_groups_and_num_candidates[0]):
             if verbose:
@@ -735,10 +750,14 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
                         f"{name} "
                         f"was higher than for any other candidate."
                     )
-                candidate_preference_rate_dict[(self.demographic_group_names[row], name)] = frac
+                candidate_preference_rate_dict[
+                    (self.demographic_group_names[row], name)
+                ] = frac
         return candidate_preference_rate_dict
 
-    def candidate_of_choice_polarization_report(self, verbose=True, non_candidate_names=None):
+    def candidate_of_choice_polarization_report(
+        self, verbose=True, non_candidate_names=None
+    ):
         """For each pair of groups, look at differences in preferences
         between those groups
 
@@ -768,12 +787,13 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         by the plurality within that group according to the sampled distric-level support value)
         is different from the `preferred candidate` of the others group
         """
-
         candidate_differ_rate_dict = {}
         if non_candidate_names is None:
             non_candidate_names = []
         non_cand_idxs = [self.candidate_names.index(n) for n in non_candidate_names]
-        sampled_voting_prefs = np.delete(self.sampled_voting_prefs, non_cand_idxs, axis=2)
+        sampled_voting_prefs = np.delete(
+            self.sampled_voting_prefs, non_cand_idxs, axis=2
+        )
 
         for dem1 in range(self.num_groups_and_num_candidates[0]):
             for dem2 in range(dem1):
@@ -878,8 +898,7 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         show_threshold=False,
         ax=None,
     ):
-        """
-        Plot kde of the margin between two candidates among the given demographic group.
+        """Plot kde of the margin between two candidates among the given demographic group.
 
         Parameters:
         ----------
@@ -959,16 +978,20 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         if return_interval:
             lower_percentile = (100 - percentile) / 2
             upper_percentile = lower_percentile + percentile
-            lower_threshold, _, samples, groups, candidate = self._calculate_polarization(
-                groups, candidate, threshold, upper_percentile
+            lower_threshold, _, samples, groups, candidate = (
+                self._calculate_polarization(
+                    groups, candidate, threshold, upper_percentile
+                )
             )
-            upper_threshold, _, samples, groups, candidate = self._calculate_polarization(
-                groups, candidate, threshold, lower_percentile
+            upper_threshold, _, samples, groups, candidate = (
+                self._calculate_polarization(
+                    groups, candidate, threshold, lower_percentile
+                )
             )
             thresholds = [lower_threshold, upper_threshold]
         else:
-            threshold, percentile, samples, groups, candidate = self._calculate_polarization(
-                groups, candidate, threshold, percentile
+            threshold, percentile, samples, groups, candidate = (
+                self._calculate_polarization(groups, candidate, threshold, percentile)
             )
             thresholds = [threshold]
 
@@ -1032,8 +1055,7 @@ class RowByColumnEI:  # pylint: disable=too-many-instance-attributes
         precinct_names=None,
         plot_as_histograms=False,
     ):
-        """
-        Optional arguments:
+        """Optional arguments:
         candidate           : str
                                 The candidate whose support we're examining
         groups              : list of str

--- a/pyei/r_by_c_models.py
+++ b/pyei/r_by_c_models.py
@@ -1,17 +1,14 @@
-"""
-Functions that return pymc models for RowByColumnEI
-"""
+"""Functions that return pymc models for RowByColumnEI"""
 
+import numpy as np
 import pymc as pm
 import pytensor.tensor as at
-import numpy as np
-
-__all__ = ["ei_multinom_dirichlet_modified", "ei_multinom_dirichlet"]
 
 
-def ei_multinom_dirichlet(group_fractions, votes_fractions, precinct_pops, lmbda1=4, lmbda2=2):
-    """
-    An implementation of the r x c dirichlet/multinomial EI model
+def ei_multinom_dirichlet(
+    group_fractions, votes_fractions, precinct_pops, lmbda1=4, lmbda2=2
+):
+    """An implementation of the r x c dirichlet/multinomial EI model
 
     Parameters:
     -----------
@@ -25,11 +22,10 @@ def ei_multinom_dirichlet(group_fractions, votes_fractions, precinct_pops, lmbda
     lmbda1: float parameter passed to the Gamma(lmbda, 1/lmbda2) distribution
     lmbda2: float parameter passed to the Gamma(lmbda, 1/lmbda2) distribution
 
-    Returns
+    Returns:
     -------
     model: A pymc3 model
     """
-
     num_precincts = len(precinct_pops)  # number of precincts
     num_rows = group_fractions.shape[0]  # number of demographic groups (r)
     num_cols = votes_fractions.shape[0]  # number of candidates or voting outcomes (c)
@@ -50,7 +46,9 @@ def ei_multinom_dirichlet(group_fractions, votes_fractions, precinct_pops, lmbda
         conc_params = pm.Gamma(
             "conc_params", alpha=lmbda1, beta=1 / lmbda2, shape=(num_rows, num_cols)
         )  # chosen to match eiPack
-        beta = pm.Dirichlet("b", a=conc_params, shape=(num_precincts, num_rows, num_cols))
+        beta = pm.Dirichlet(
+            "b", a=conc_params, shape=(num_precincts, num_rows, num_cols)
+        )
         # num_precincts x r x c
         theta = (group_fractions_extended * beta).sum(axis=1)
         pm.Multinomial(
@@ -66,8 +64,7 @@ def ei_multinom_dirichlet(group_fractions, votes_fractions, precinct_pops, lmbda
 def ei_multinom_dirichlet_modified(
     group_fractions, votes_fractions, precinct_pops, pareto_scale=5, pareto_shape=1
 ):
-    """
-    An implementation of the r x c dirichlet/multinomial EI model with reparametrized hyperpriors
+    """An implementation of the r x c dirichlet/multinomial EI model with reparametrized hyperpriors
 
     Parameters:
     -----------
@@ -79,16 +76,15 @@ def ei_multinom_dirichlet_modified(
     precinct_pops: Length-num_precincts vector giving size of each precinct population of interest
         (e.g. voting population) (sometimes denoted N)
 
-    Returns
+    Returns:
     -------
     model: A pymc3 model
 
-    Notes
+    Notes:
     -----
     Reparametrizing of the hyperpriors to give (hopefully) better geometry for sampling.
     Also gives intuitive interpretation of hyperparams as mean and counts
     """
-
     num_precincts = len(precinct_pops)  # number of precincts
     num_rows = group_fractions.shape[0]  # number of demographic groups (r)
     num_cols = votes_fractions.shape[0]  # number of candidates or voting outcomes (c)
@@ -104,9 +100,15 @@ def ei_multinom_dirichlet_modified(
 
     with pm.Model() as model:
         # TODO: make b vs. beta naming consistent
-        kappa = pm.Pareto("kappa", alpha=pareto_shape, m=pareto_scale, shape=num_rows)  # size r
-        phi = pm.Dirichlet("phi", a=np.ones(num_cols), shape=(num_rows, num_cols))  # r x c
-        phi_kappa = pm.Deterministic("phi_kappa", at.transpose(kappa * at.transpose(phi)))
+        kappa = pm.Pareto(
+            "kappa", alpha=pareto_shape, m=pareto_scale, shape=num_rows
+        )  # size r
+        phi = pm.Dirichlet(
+            "phi", a=np.ones(num_cols), shape=(num_rows, num_cols)
+        )  # r x c
+        phi_kappa = pm.Deterministic(
+            "phi_kappa", at.transpose(kappa * at.transpose(phi))
+        )
         beta = pm.Dirichlet("b", a=phi_kappa, shape=(num_precincts, num_rows, num_cols))
         # num_precincts x r x c
         theta = (group_fractions_extended * beta).sum(axis=1)  # sum across num_rows

--- a/pyei/two_by_two.py
+++ b/pyei/two_by_two.py
@@ -1,31 +1,25 @@
-"""
-Models and fitting for 2x2 methods
-
-"""
+"""Models and fitting for 2x2 methods"""
 
 import warnings
-import pymc as pm
+
 import numpy as np
-import pytensor.tensor as at
+import pymc as pm
 import pytensor
-from .plot_utils import (
-    plot_conf_or_credible_interval,
+import pytensor.tensor as at
+
+from pyei.plot_utils import (
     plot_boxplots,
-    plot_kdes,
-    plot_precincts,
-    plot_polarization_kde,
-    plot_summary,
+    plot_conf_or_credible_interval,
     plot_intervals_all_precincts,
+    plot_kdes,
+    plot_polarization_kde,
+    plot_precincts,
+    plot_summary,
 )
 
-__all__ = ["TwoByTwoEI", "ei_beta_binom_model_modified"]
 
-
-def truncated_normal_asym(
-    group_fraction, votes_fraction, precinct_pops
-):  # pylint: disable=too-many-locals
-    """
-    A modification of king97's truncated normal that puts some broad priors
+def _truncated_normal_asym(group_fraction, votes_fraction, precinct_pops):  # pylint: disable=too-many-locals
+    """A modification of king97's truncated normal that puts some broad priors
     over the parameters of the truncated normal dist
 
     Parameters
@@ -37,7 +31,7 @@ def truncated_normal_asym(
     precinct_pops: Length-p vector giving size of each precinct population of interest
          (e.g. voting population)
 
-    Returns
+    Returns:
     -------
     model: A pymc3 model
 
@@ -45,7 +39,9 @@ def truncated_normal_asym(
     num_precincts = len(precinct_pops)
     b_1_l_bound = np.maximum(0, (votes_fraction - 1 + group_fraction) / group_fraction)
     b_1_u_bound = np.minimum(1, votes_fraction / group_fraction)
-    b_2_l_bound = np.maximum(0, (votes_fraction - group_fraction) / (1 - group_fraction))
+    b_2_l_bound = np.maximum(
+        0, (votes_fraction - group_fraction) / (1 - group_fraction)
+    )
     b_2_u_bound = np.minimum(1, (votes_fraction) / (1 - group_fraction))
 
     # For stability, use whichever of b_1 and b_2 has the broader width between bounds as
@@ -106,7 +102,9 @@ def truncated_normal_asym(
         )
 
         votes_frac_mean = mu_i + w_i * (upper_b - tn_mean_upper) / (sigma_upper**2)
-        votes_frac_var = pm.Deterministic("votes_frac_var", sigma_i_sq - w_i**2 / (sigma_upper**2))
+        votes_frac_var = pm.Deterministic(
+            "votes_frac_var", sigma_i_sq - w_i**2 / (sigma_upper**2)
+        )
 
         votes_frac_l_bound = group_fraction * upper_b
         votes_frac_u_bound = (1 - group_fraction) + group_fraction * upper_b
@@ -130,8 +128,7 @@ def truncated_normal_asym(
 def ei_beta_binom_model_modified(
     group_fraction, votes_fraction, precinct_pops, pareto_scale=8, pareto_shape=2
 ):
-    """
-    An modification of the 2 x 2 beta/binomial EI model from King, Rosen, Tanner 1999,
+    """An modification of the 2 x 2 beta/binomial EI model from King, Rosen, Tanner 1999,
     with (scaled) Pareto distributions over each parameters of the beta distribution,
     for better sampling geometry
 
@@ -148,11 +145,11 @@ def ei_beta_binom_model_modified(
     pareto_shape: A positive real number. The shape paremeter passed to the
         pareto hyperparamters
 
-    Returns
+    Returns:
     -------
     model: A pymc3 model
 
-    Notes
+    Notes:
     -----
     Reparametrizing of the hyperpriors to give (hopefully) better geometry for sampling.
     Also gives intuitive interpretation of hyperparams as mean and counts
@@ -187,8 +184,7 @@ def ei_beta_binom_model_modified(
 
 
 def ei_beta_binom_model(group_fraction, votes_fraction, precinct_pops, lmbda):
-    """
-    2 x 2 beta/binomial EI model from King, Rosen, Tanner 1999
+    """2 x 2 beta/binomial EI model from King, Rosen, Tanner 1999
 
     Parameters
     ----------
@@ -203,11 +199,10 @@ def ei_beta_binom_model(group_fraction, votes_fraction, precinct_pops, lmbda):
         King sets this to 0.5, but lower seems to produce better geometry
         for sampling
 
-    Returns
+    Returns:
     -------
     model: A pymc3 model
     """
-
     votes_count_obs = votes_fraction * precinct_pops
     num_precincts = len(precinct_pops)
     with pm.Model() as model:
@@ -224,9 +219,8 @@ def ei_beta_binom_model(group_fraction, votes_fraction, precinct_pops, lmbda):
     return model
 
 
-def log_binom_sum(lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b_2_curr, prev):
-    """
-    Helper function for computing log prob of convolution of binomial
+def _log_binom_sum(lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b_2_curr, prev):
+    """Helper function for computing log prob of convolution of binomial
 
     Parameters
     ----------
@@ -241,27 +235,27 @@ def log_binom_sum(lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b_2_curr, 
         in the complement of the given demographic group votes for the given candidate
     prev: the partial sum of the log prob of the convolution of binomials
 
-    Returns
+    Returns:
     -------
     prev + component_for_current_precinct : sum of the previous value of the partial sum
         for the log prob of the convolution of binomials and an additional term for one
         precinct
 
     """
-
     # votes_within_group_count is y_0i in Wakefield's notation, the count of votes from
     # given group for given candidate within precinct i (unobserved)
     votes_within_group_count = at.arange(lower, upper)
     component_for_current_precinct = pm.math.logsumexp(
         pm.logp(pm.Binomial.dist(n0_curr, b_1_curr), votes_within_group_count)
-        + pm.logp(pm.Binomial.dist(n1_curr, b_2_curr), obs_vote - votes_within_group_count)
+        + pm.logp(
+            pm.Binomial.dist(n1_curr, b_2_curr), obs_vote - votes_within_group_count
+        )
     )
     return prev + component_for_current_precinct
 
 
-def binom_conv_log_p(b_1, b_2, n_0, n_1, upper, lower, obs_votes):
-    """
-    Log probability for convolution of binomials
+def _binom_conv_log_p(b_1, b_2, n_0, n_1, upper, lower, obs_votes):
+    """Log probability for convolution of binomials
 
     Parameters
     ----------
@@ -277,17 +271,16 @@ def binom_conv_log_p(b_1, b_2, n_0, n_1, upper, lower, obs_votes):
     deographic group for given candidate within precinct
     (corresponds to votes_within_group_count in log_binom_sum and y_0i in Wakefield's)
 
-    Returns
+    Returns:
     -------
     A theano tensor giving the log probability of b_1, b_2 (given the other parameters)
 
-    Notes
+    Notes:
     -----
     See Wakefield 2004 equation 4
     """
-
     result, _ = pytensor.scan(
-        fn=log_binom_sum,
+        fn=_log_binom_sum,
         outputs_info={"taps": [-1], "initial": at.as_tensor(np.array([0.0]))},
         sequences=[
             at.as_tensor(lower),
@@ -422,8 +415,7 @@ def binom_conv_log_p(b_1, b_2, n_0, n_1, upper, lower, obs_votes):
 
 
 class TwoByTwoEIBaseBayes:
-    """
-    Init, summary, plots for 2 x 2 EI models that proceed via sampling
+    """Init, summary, plots for 2 x 2 EI models that proceed via sampling
 
     Note: does not assume precinct level samples are available,
     because this is not possible for goodman_er_bayes. So, plots of precinct
@@ -434,8 +426,7 @@ class TwoByTwoEIBaseBayes:
     """
 
     def __init__(self, model_name, **additional_model_params):
-        """
-        model_name: str
+        """model_name: str
             The name of one of the models ( "king99", "king99_pareto_modification",
              "truncated_normal",
             "goodman_er_bayes")
@@ -466,7 +457,8 @@ class TwoByTwoEIBaseBayes:
 
     def _voting_prefs_array(self):
         """Bundles together the samples as num_samples x 2 x 1 array,
-        for ease of passing to plots"""
+        for ease of passing to plots
+        """
         num_samples = len(self.sampled_voting_prefs[0])
         sampled_voting_prefs = np.empty((num_samples, 2, 1))  # num_samples x 2 x 1
         sampled_voting_prefs[:, 0, 0] = self.sampled_voting_prefs[0]
@@ -475,8 +467,8 @@ class TwoByTwoEIBaseBayes:
 
     def calculate_summary(self):
         """Calculate point estimates (post. means) and 95% equal-tailed credible intervals
-        Assumes sampled_voting_prefs has already been set"""
-
+        Assumes sampled_voting_prefs has already been set
+        """
         # compute point estimates
         self.posterior_mean_voting_prefs[0] = self.sampled_voting_prefs[0].mean()
         self.posterior_mean_voting_prefs[1] = self.sampled_voting_prefs[1].mean()
@@ -490,8 +482,10 @@ class TwoByTwoEIBaseBayes:
             self.sampled_voting_prefs[1], percentiles
         )
 
-    def _calculate_polarization(self, threshold=None, percentile=None, reference_group=0):
-        """calculate percentile given a threshold, or threshold if given a percentile
+    def _calculate_polarization(
+        self, threshold=None, percentile=None, reference_group=0
+    ):
+        """Calculate percentile given a threshold, or threshold if given a percentile
         exactly one of percentile and threshold must be null
 
         Parameters
@@ -509,7 +503,7 @@ class TwoByTwoEIBaseBayes:
             (group 0 preferences - group 1 preferences). If 1, the thresholds are
             calculated as (group 1 preferences - group 0 preferences)
 
-        Notes
+        Notes:
         -----
         Exactly one of threshold and percentile must be None
 
@@ -523,7 +517,9 @@ class TwoByTwoEIBaseBayes:
             group_complement = self.demographic_group_name
 
         if percentile is None and threshold is not None:
-            percentile = 100 * (samples > threshold).sum() / len(self.sampled_voting_prefs[0])
+            percentile = (
+                100 * (samples > threshold).sum() / len(self.sampled_voting_prefs[0])
+            )
         elif threshold is None and percentile is not None:
             threshold = np.percentile(samples, 100 - percentile)
         else:
@@ -535,9 +531,10 @@ class TwoByTwoEIBaseBayes:
             )
         return threshold, percentile, samples, [group, group_complement]
 
-    def polarization_report(self, threshold=None, percentile=None, reference_group=0, verbose=True):
-        """
-        For a given threshold, return the probability that difference between the group's
+    def polarization_report(
+        self, threshold=None, percentile=None, reference_group=0, verbose=True
+    ):
+        """For a given threshold, return the probability that difference between the group's
         preferences for the given candidate is more than threshold
         OR
         For a given confidence level, return the associated central credible interval for
@@ -561,7 +558,7 @@ class TwoByTwoEIBaseBayes:
         verbose: bool
             If True, print out a report
 
-        Notes
+        Notes:
         -----
         Exactly one of threshold and percentile must be None
         """
@@ -616,7 +613,7 @@ class TwoByTwoEIBaseBayes:
         """
 
     def plot_kde(self, ax=None):
-        """kernel density estimate/ histogram plot
+        """Kernel density estimate/ histogram plot
         Optional arguments:
         ax  :  matplotlib axes object
         """
@@ -631,7 +628,8 @@ class TwoByTwoEIBaseBayes:
     def plot_boxplot(self, ax=None):
         """Boxplot of voting prefs for each group
         Optional arguments:
-        ax  :  matplotlib axes object"""
+        ax  :  matplotlib axes object
+        """
         return plot_boxplots(
             self._voting_prefs_array(),
             self.group_names_for_display(),
@@ -666,8 +664,7 @@ class TwoByTwoEIBaseBayes:
         ax=None,
         color="steelblue",
     ):
-        """
-        Plot kde of differences between voting preferences
+        """Plot kde of differences between voting preferences
 
         Parameters
         ----------
@@ -691,7 +688,7 @@ class TwoByTwoEIBaseBayes:
             Specifies a color for matplotlib to be used in the histogram/kde.
             default="steelblue"
 
-        Returns
+        Returns:
         -------
         Matplotlib axis object
 
@@ -727,13 +724,10 @@ class TwoByTwoEIBaseBayes:
 
 
 class TwoByTwoEI(TwoByTwoEIBaseBayes):
-    """
-    Fitting and plotting for king97, king99, and wakefield models
-    """
+    """Fitting and plotting for king97, king99, and wakefield models"""
 
     def __init__(self, model_name, **additional_model_params):
-        """
-        model_name: str
+        """model_name: str
             Name of model: can be 'king97', 'king99', 'king99_pareto_modification'
             'wakefield_beta' or 'wakefield normal'
         additional_model_params
@@ -794,7 +788,8 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
 
         # check that lengths of group_fraction, votes_fraction, precinct_pops match
         if not (
-            len(group_fraction) == len(votes_fraction) and len(votes_fraction) == len(precinct_pops)
+            len(group_fraction) == len(votes_fraction)
+            and len(votes_fraction) == len(precinct_pops)
         ):
             raise ValueError(
                 """Mismatching num_precincts in inputs. \n
@@ -862,17 +857,25 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
         # number of voters the demographic group who voted for the candidate
         # in each precinct
         samples_converted_to_pops_gp1 = (
-            self.sim_trace["posterior"]["b_1"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_1"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
             * self.precinct_pops
         )  # shape: num_samples x num_precincts
         samples_converted_to_pops_gp2 = (
-            self.sim_trace["posterior"]["b_2"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_2"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
             * self.precinct_pops
         )  # shape: num_samples x num_precincts
 
         # obtain samples of total votes summed across all precinct for the candidate for each group
-        samples_of_votes_summed_across_district_gp1 = samples_converted_to_pops_gp1.sum(axis=1)
-        samples_of_votes_summed_across_district_gp2 = samples_converted_to_pops_gp2.sum(axis=1)
+        samples_of_votes_summed_across_district_gp1 = samples_converted_to_pops_gp1.sum(
+            axis=1
+        )
+        samples_of_votes_summed_across_district_gp2 = samples_converted_to_pops_gp2.sum(
+            axis=1
+        )
 
         # obtain samples of the districtwide proportion of each demog. group voting for candidate
         self.sampled_voting_prefs[0] = (
@@ -894,7 +897,9 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
 
         # The stracking on the next line convers to a num_samples x num_precincts array
         precinct_level_samples_gp1 = (
-            self.sim_trace["posterior"]["b_1"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_1"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
         )
         precinct_posterior_means_gp1 = precinct_level_samples_gp1.mean(axis=0)
         precinct_credible_intervals_gp1 = np.percentile(
@@ -903,7 +908,9 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
 
         # The stracking on the next line convers to a num_samples x num_precincts array
         precinct_level_samples_gp2 = (
-            self.sim_trace["posterior"]["b_2"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_2"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
         )
         precinct_posterior_means_gp2 = precinct_level_samples_gp2.mean(axis=0)
         precinct_credible_intervals_gp2 = np.percentile(
@@ -928,7 +935,9 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
         """Plot of point estimates and credible intervals for each precinct"""
         # TODO: Fix use of axes
 
-        precinct_posterior_means, precinct_credible_intervals = self.precinct_level_estimates()
+        precinct_posterior_means, precinct_credible_intervals = (
+            self.precinct_level_estimates()
+        )
         precinct_posterior_means_gp1 = precinct_posterior_means[:, 0, 0]
         precinct_posterior_means_gp2 = precinct_posterior_means[:, 1, 0]
         precinct_credible_intervals_gp1 = precinct_credible_intervals[:, 0, 0, :]
@@ -989,10 +998,14 @@ class TwoByTwoEI(TwoByTwoEIBaseBayes):
                                 with histograms instead of kdes
         """
         voting_prefs_group1 = (
-            self.sim_trace["posterior"]["b_1"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_1"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
         )
         voting_prefs_group2 = (
-            self.sim_trace["posterior"]["b_2"].stack(all_draws=["chain", "draw"]).values.T
+            self.sim_trace["posterior"]["b_2"]
+            .stack(all_draws=["chain", "draw"])
+            .values.T
         )
         group_names = self.group_names_for_display()
         if precinct_names is not None:

--- a/test/test_greiner_quinn.py
+++ b/test/test_greiner_quinn.py
@@ -2,28 +2,30 @@
 
 # pylint: disable=duplicate-code
 import random
-import pytest
+
 import numpy as np
+import pytest
 import scipy.stats as st
 
-
 from pyei import data
-from pyei.r_by_c import RowByColumnEI
+from pyei.distribution_utils import non_central_hypergeometric_sample
 from pyei.greiner_quinn_gibbs_sampling import (
-    get_initial_internal_count_sample,
-    theta_to_omega,
+    _get_initial_internal_count_sample,
+    _theta_to_omega,
     greiner_quinn_gibbs_sample,
 )
-from pyei.distribution_utils import non_central_hypergeometric_sample
+from pyei.r_by_c import RowByColumnEI
 
 
 @pytest.fixture(scope="session")
 def example_r_by_c_data_asym():
-    """trimmed santa clara dataset with r not equal to c"""
+    """Trimmed santa clara dataset with r not equal to c"""
     sc_data = data.Datasets.Santa_Clara.to_dataframe()
     sc_data = sc_data.iloc[:10, :]
     precinct_pops = np.array(sc_data["total2"])
-    votes_fractions = np.array(sc_data[["pct_for_hardy2", "pct_for_kolstad2", "pct_for_nadeem2"]]).T
+    votes_fractions = np.array(
+        sc_data[["pct_for_hardy2", "pct_for_kolstad2", "pct_for_nadeem2"]]
+    ).T
     candidate_names = ["Hardy", "Kolstad", "Nadeem"]
     group_fractions = np.array(sc_data[["pct_asian_vote", "pct_non_asian_vote"]]).T
     demographic_group_names = ["asian", "non_asian"]
@@ -61,13 +63,23 @@ def test_get_initial_internal_count_sample(
     vote_counts = example_r_by_c_data_asym["vote_counts"]
     group_counts = example_r_by_c_data_asym["group_counts"]
     precinct_pops = example_r_by_c_data_asym["precinct_pops"]
-    samp = get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops)
-    samp_py = get_initial_internal_count_sample.py_func(group_counts, vote_counts, precinct_pops)
+    samp = _get_initial_internal_count_sample(group_counts, vote_counts, precinct_pops)
+    samp_py = _get_initial_internal_count_sample.py_func(
+        group_counts, vote_counts, precinct_pops
+    )
 
-    assert np.all(samp.sum(axis=2) - group_counts == 0)  # sample respects given group counts
-    assert np.all(samp.sum(axis=1) - vote_counts == 0)  # sample respects given vote counts
-    assert np.all(samp_py.sum(axis=2) - group_counts == 0)  # sample respects given group counts
-    assert np.all(samp_py.sum(axis=1) - vote_counts == 0)  # sample respects given vote counts
+    assert np.all(
+        samp.sum(axis=2) - group_counts == 0
+    )  # sample respects given group counts
+    assert np.all(
+        samp.sum(axis=1) - vote_counts == 0
+    )  # sample respects given vote counts
+    assert np.all(
+        samp_py.sum(axis=2) - group_counts == 0
+    )  # sample respects given group counts
+    assert np.all(
+        samp_py.sum(axis=1) - vote_counts == 0
+    )  # sample respects given vote counts
 
 
 def test_theta_to_omega():
@@ -76,7 +88,7 @@ def test_theta_to_omega():
     c = 4
     alpha = np.ones(c)
     theta = st.dirichlet.rvs(alpha, size=(num_precincts, r))
-    omega = theta_to_omega(theta)
+    omega = _theta_to_omega(theta)
     assert omega.shape[2] == c - 1
     np.testing.assert_almost_equal(
         omega[3, 2, 1], np.log(theta[3, 2, 1] / theta[3, 2, c - 1]), decimal=4

--- a/test/test_two_by_two.py
+++ b/test/test_two_by_two.py
@@ -1,18 +1,17 @@
 """Test two by two ecological inference."""
 
-import pytest
 import numpy as np
+import pytest
 import scipy.stats as st
 from scipy.special import logsumexp
 
-from pyei import two_by_two
-from pyei import data
+from pyei import data, two_by_two
 from pyei.two_by_two import TwoByTwoEI
 
 
 @pytest.fixture(scope="session")
 def example_two_by_two_data():
-    """load santa clara data to test two by two ei and plots"""  #
+    """Load santa clara data to test two by two ei and plots"""  #
     sc_data = data.Datasets.Santa_Clara.to_dataframe()
     group_fractions = np.array(sc_data["pct_e_asian_vote"])
     votes_fractions = np.array(sc_data["pct_for_hardy2"])  #
@@ -32,8 +31,10 @@ def example_two_by_two_data():
 
 @pytest.fixture(scope="session")
 def example_two_by_two_ei(example_two_by_two_data):  # pylint: disable=redefined-outer-name
-    """run example two by two ei method - can use to test plotting"""
-    ei_ex = TwoByTwoEI(model_name="king99_pareto_modification", pareto_scale=8, pareto_shape=2)
+    """Run example two by two ei method - can use to test plotting"""
+    ei_ex = TwoByTwoEI(
+        model_name="king99_pareto_modification", pareto_scale=8, pareto_shape=2
+    )
     ei_ex.fit(  #
         example_two_by_two_data["group_fractions"],
         example_two_by_two_data["votes_fractions"],
@@ -70,7 +71,9 @@ def generate_kwargs_for_log_binom_sum():
     return kwargs
 
 
-def log_binom_sum_in_scipy(lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b_2_curr, prev):
+def log_binom_sum_in_scipy(
+    lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b_2_curr, prev
+):
     """Reimplement theano logic in scipy to make sure it matches."""
     votes_withing_group_count = np.arange(lower, upper)
     return (
@@ -85,7 +88,9 @@ def log_binom_sum_in_scipy(lower, upper, obs_vote, n0_curr, n1_curr, b_1_curr, b
 def test_log_binom_sum():
     kwargs = generate_kwargs_for_log_binom_sum()
     np.testing.assert_almost_equal(
-        two_by_two.log_binom_sum(**kwargs).eval(), log_binom_sum_in_scipy(**kwargs), decimal=4
+        two_by_two._log_binom_sum(**kwargs).eval(),
+        log_binom_sum_in_scipy(**kwargs),
+        decimal=4,
     )
 
 
@@ -115,7 +120,9 @@ def test_binom_conv_log_p():
         )
     )
 
-    theano_result = two_by_two.binom_conv_log_p(b_1, b_2, n_0, n_1, upper, lower, obs_votes).eval()
+    theano_result = two_by_two._binom_conv_log_p(
+        b_1, b_2, n_0, n_1, upper, lower, obs_votes
+    ).eval()
 
     # Now compute the result using scipy
     prev = np.array([0])
@@ -134,4 +141,7 @@ def test_polarization_report(example_two_by_two_ei):  # pylint: disable=redefine
 
     assert prob_20 >= prob_40
     assert thresh_95_range[1] > thresh_95_range[0]
-    assert thresh_95_range[1] - thresh_95_range[0] >= thresh_90_range[1] - thresh_90_range[0]
+    assert (
+        thresh_95_range[1] - thresh_95_range[0]
+        >= thresh_90_range[1] - thresh_90_range[0]
+    )


### PR DESCRIPTION
BREAKING CHANGE: Rename internal helper functions to follow Python conventions

- Convert all relative imports to absolute imports within package
- Remove __all__ specifiers from all module files
- Mark internal functions as private with leading underscore:
  * plot_utils: size_ticks → _size_ticks, size_yticklabels → _size_yticklabels
  * plot_utils: plot_single_ridgeplot → _plot_single_ridgeplot, plot_single_histogram → _plot_single_histogram
  * two_by_two: log_binom_sum → _log_binom_sum, binom_conv_log_p → _binom_conv_log_p
  * goodmans_er: goodmans_er_bayes_model → _goodmans_er_bayes_model, goodmans_er_bayes_pop_weighted_model → _goodmans_er_bayes_pop_weighted_model
  * distribution_utils: r_function → _r_function, sample_low_to_high → _sample_low_to_high, sample_high_to_low → _sample_high_to_low
  * greiner_quinn_gibbs_sampling: sample_Sigma → _sample_Sigma, sample_mu → _sample_mu, proposal_dist_generate_sample → _proposal_dist_generate_sample, log_unnormalized_pdf → _log_unnormalized_pdf, theta_to_omega → _theta_to_omega, sample_theta → _sample_theta, omega_to_theta → _omega_to_theta, sample_internal_cell_counts → _sample_internal_cell_counts, get_initial_internal_count_sample → _get_initial_internal_count_sample

- Update all internal function calls to use new private names
- Fix test imports and function calls to match refactored code
- Add comprehensive migration documentation (MIGRATION_NOTES.md, CHANGELOG.md)

Public API remains unchanged. Migration required for code importing private functions. See MIGRATION_NOTES.md for detailed migration instructions.